### PR TITLE
Add setup script for environment management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Moogla
+
+Moogla is a self‑hosted LLM runtime and orchestration framework for power users. It combines
+local-first execution with the flexibility required for production‑grade workflows.
+
+This repository starts with a minimal project layout and conventions so that new
+features can be added incrementally. The goal is to keep the codebase modular,
+observable and developer friendly.
+
+## Project Layout
+
+```
+.
+├── src/            # Python package source
+│   └── moogla/     # Moogla core modules
+├── tests/          # Unit and integration tests
+├── pyproject.toml  # Build system and dependency configuration
+└── README.md
+```
+
+## Getting Started
+
+1. Run the setup script to create a virtual environment and install dependencies:
+
+   ```bash
+   ./scripts/setup.sh -d
+   ```
+
+   The `-d` flag installs development tools like `pytest` and `pre-commit`.
+
+2. After installation, run the CLI to see available commands:
+
+   ```bash
+   moogla --help
+   ```
+
+## Contributing Guidelines
+
+- Use the `src` layout for all packages and modules.
+- Keep functions small and composable.
+- Write unit tests for new behavior in `tests/`.
+- Use type hints and docstrings.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "moogla"
+version = "0.0.1"
+description = "Local-first LLM runtime and orchestration framework"
+authors = [{name="Rehkad"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+dependencies = [
+    "typer>=0.9",
+    "fastapi>=0.110",
+    "uvicorn>=0.28",
+]
+
+[project.scripts]
+moogla = "moogla.cli:app"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -e
+
+usage() {
+    cat <<USAGE
+Usage: $0 [OPTIONS]
+
+Options:
+  -e, --env PATH   Virtual environment location (default: .venv)
+  --no-venv        Skip creating a virtual environment
+  -d, --dev        Install development dependencies (pytest, pre-commit)
+  -t, --test       Run tests after installation
+  -h, --help       Show this help and exit
+USAGE
+}
+
+ENV_PATH=".venv"
+CREATE_VENV=1
+INSTALL_DEV=0
+RUN_TESTS=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -e|--env)
+            ENV_PATH="$2"
+            shift 2
+            ;;
+        --no-venv)
+            CREATE_VENV=0
+            shift
+            ;;
+        -d|--dev)
+            INSTALL_DEV=1
+            shift
+            ;;
+        -t|--test)
+            RUN_TESTS=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ $CREATE_VENV -eq 1 ]]; then
+    python -m venv "$ENV_PATH"
+    # shellcheck disable=SC1090
+    source "$ENV_PATH/bin/activate"
+fi
+
+pip install -e .
+if [[ $INSTALL_DEV -eq 1 ]]; then
+    pip install pytest pre-commit
+    if command -v pre-commit >/dev/null 2>&1; then
+        pre-commit install
+    fi
+fi
+
+if [[ $RUN_TESTS -eq 1 ]]; then
+    pytest -q
+fi
+
+echo "Setup complete"

--- a/src/moogla/__init__.py
+++ b/src/moogla/__init__.py
@@ -1,0 +1,4 @@
+"""Moogla core package."""
+
+__all__ = ["__version__"]
+__version__ = "0.0.1"

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -1,0 +1,12 @@
+import typer
+from .server import start_server
+
+app = typer.Typer(help="Moogla command line interface")
+
+@app.command()
+def serve(host: str = "0.0.0.0", port: int = 11434):
+    """Start the Moogla HTTP server."""
+    start_server(host=host, port=port)
+
+if __name__ == "__main__":
+    app()

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI(title="Moogla API")
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+def start_server(host: str = "0.0.0.0", port: int = 11434) -> None:
+    """Run the HTTP server."""
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from moogla.server import app
+
+client = TestClient(app)
+
+def test_health_check():
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to automate virtualenv creation and optional dev setup
- update `.gitignore` to exclude `.venv` directories
- document setup script usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_685a1c7c5e248332b4c5642d4137b9c7