### PR TITLE
Expand Moogla API and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ observable and developer friendly.
    moogla --help
    ```
 
+### Example Usage
+
+Pull a model and start the server with a custom plugin:
+
+```bash
+moogla pull codellama:13b
+moogla serve --plugin tests.dummy_plugin
+```
+
+You can then query the chat completion endpoint:
+
+```bash
+curl -X POST http://localhost:11434/v1/chat/completions \
+  -d '{"messages": [{"role": "user", "content": "hello"}]}'
+```
+
 ## Contributing Guidelines
 
 - Use the `src` layout for all packages and modules.

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -1,12 +1,27 @@
+from typing import List
+
 import typer
+
 from .server import start_server
 
 app = typer.Typer(help="Moogla command line interface")
 
 @app.command()
-def serve(host: str = "0.0.0.0", port: int = 11434):
+def serve(
+    host: str = "0.0.0.0",
+    port: int = 11434,
+    plugin: List[str] = typer.Option(
+        None, '--plugin', '-p', help='Plugin module to load', show_default=False
+    ),
+):
     """Start the Moogla HTTP server."""
-    start_server(host=host, port=port)
+    start_server(host=host, port=port, plugin_names=plugin)
+
+
+@app.command()
+def pull(model: str):
+    """Pull a model into the local cache (stub)."""
+    typer.echo(f"Pulling {model} ... done.")
 
 if __name__ == "__main__":
     app()

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -1,0 +1,31 @@
+from importlib import import_module
+from types import ModuleType
+from typing import Callable, List, Optional
+
+
+class Plugin:
+    """Simple wrapper around a plugin module."""
+
+    def __init__(self, module: ModuleType) -> None:
+        self.module = module
+        self.preprocess: Optional[Callable[[str], str]] = getattr(module, "preprocess", None)
+        self.postprocess: Optional[Callable[[str], str]] = getattr(module, "postprocess", None)
+
+    def run_preprocess(self, text: str) -> str:
+        if self.preprocess:
+            return self.preprocess(text)
+        return text
+
+    def run_postprocess(self, text: str) -> str:
+        if self.postprocess:
+            return self.postprocess(text)
+        return text
+
+
+def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
+    """Import and initialize plugins from module names."""
+    plugins: List[Plugin] = []
+    for name in names or []:
+        module = import_module(name)
+        plugins.append(Plugin(module))
+    return plugins

--- a/tests/dummy_plugin.py
+++ b/tests/dummy_plugin.py
@@ -1,0 +1,5 @@
+def preprocess(text: str) -> str:
+    return text.upper()
+
+def postprocess(text: str) -> str:
+    return f"!!{text}!!"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
-from moogla.server import app
+from moogla.server import create_app
 
-client = TestClient(app)
+client = TestClient(create_app())
 
 def test_health_check():
     resp = client.get('/health')

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from moogla.server import create_app
+
+
+def test_chat_completion():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["choices"][0]["message"]["content"] == "olleh"
+
+
+def test_completion_endpoint():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "cba"
+
+
+def test_plugins():
+    app = create_app(["tests.dummy_plugin"])
+    client = TestClient(app)
+    resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "!!OLLEH!!"


### PR DESCRIPTION
## Summary
- extend CLI with `pull` command and plugin option
- add plugin loading helpers
- expand HTTP server with completion endpoints
- document example usage in README
- add plugin tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1f90b48483328f7acf39b41993e0