### PR TITLE
Implement minimal web UI

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
 import uvicorn
 
 app = FastAPI(title="Moogla API")
@@ -6,6 +8,51 @@ app = FastAPI(title="Moogla API")
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+
+class EchoRequest(BaseModel):
+    """Payload for echo endpoint."""
+
+    message: str
+
+
+@app.get("/", response_class=HTMLResponse)
+def ui_page() -> HTMLResponse:
+    """Serve a minimal web UI."""
+    html = """<!DOCTYPE html>
+<html>
+<head>
+  <title>Moogla UI</title>
+</head>
+<body>
+  <h1>Moogla UI</h1>
+  <div>
+    <input id=\"message\" placeholder=\"Type a message\" />
+    <button onclick=\"send()\">Send</button>
+  </div>
+  <pre id=\"response\"></pre>
+  <script>
+    async function send() {
+      const msg = document.getElementById('message').value;
+      const res = await fetch('/echo', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({message: msg})
+      });
+      const data = await res.json();
+      document.getElementById('response').textContent = JSON.stringify(data, null, 2);
+    }
+  </script>
+</body>
+</html>
+"""
+    return HTMLResponse(content=html)
+
+
+@app.post("/echo")
+def echo(payload: EchoRequest):
+    """Echo back the provided message."""
+    return {"echo": payload.message}
 
 def start_server(host: str = "0.0.0.0", port: int = 11434) -> None:
     """Run the HTTP server."""

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,3 +7,15 @@ def test_health_check():
     resp = client.get('/health')
     assert resp.status_code == 200
     assert resp.json() == {'status': 'ok'}
+
+
+def test_ui_page():
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert 'Moogla UI' in resp.text
+
+
+def test_echo():
+    resp = client.post('/echo', json={'message': 'hi'})
+    assert resp.status_code == 200
+    assert resp.json() == {'echo': 'hi'}


### PR DESCRIPTION
## Summary
- serve a simple HTML page from the root endpoint
- add an echo endpoint used by the UI
- test the UI and new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2084f4408332b18098195f8f620b