### PR TITLE
Add basic web UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ moogla = "moogla.cli:app"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"moogla.web" = ["*"]
+

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from pydantic import BaseModel
 import uvicorn
 
@@ -12,6 +14,10 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
     plugins = load_plugins(plugin_names)
 
     app = FastAPI(title="Moogla API")
+
+    static_dir = Path(__file__).resolve().parent / "web"
+    if static_dir.exists():
+        app.mount("/app", StaticFiles(directory=static_dir, html=True), name="static")
 
     @app.get("/health")
     def health_check():

--- a/src/moogla/web/README.md
+++ b/src/moogla/web/README.md
@@ -1,0 +1,14 @@
+# Moogla Web Interface
+
+This folder contains a minimal web interface for interacting with a running
+Moogla server. The UI is styled using [Tailwind CSS](https://tailwindcss.com).
+
+A reference design is available in Figma. You can duplicate it from:
+
+```
+https://www.figma.com/community/file/13978200592474809/Moogla-UI-Demo
+```
+
+To use the interface, start the Moogla server and open `index.html` in your
+browser. Messages are sent to the `/v1/chat/completions` endpoint and replies are
+displayed on the page.

--- a/src/moogla/web/app.js
+++ b/src/moogla/web/app.js
@@ -1,0 +1,22 @@
+async function sendMessage() {
+    const input = document.getElementById('message');
+    const text = input.value.trim();
+    if (!text) return;
+    const chat = document.getElementById('chat');
+    chat.innerHTML += `<div class="text-right mb-2"><span class="bg-blue-100 px-2 py-1 rounded">${text}</span></div>`;
+    input.value = '';
+    const resp = await fetch('/v1/chat/completions', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({messages: [{role: 'user', content: text}]})
+    });
+    const data = await resp.json();
+    const reply = data.choices[0].message.content;
+    chat.innerHTML += `<div class="text-left mb-2"><span class="bg-green-100 px-2 py-1 rounded">${reply}</span></div>`;
+    chat.scrollTop = chat.scrollHeight;
+}
+
+document.getElementById('send').addEventListener('click', sendMessage);
+document.getElementById('message').addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') sendMessage();
+});

--- a/src/moogla/web/index.html
+++ b/src/moogla/web/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Moogla Chat</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-4">
+    <div class="container mx-auto max-w-xl">
+        <h1 class="text-2xl font-bold mb-4">Moogla Chat</h1>
+        <div id="chat" class="bg-white p-4 rounded shadow h-64 overflow-y-auto mb-4"></div>
+        <div class="flex">
+            <input id="message" class="flex-grow border rounded-l px-3 py-2" type="text" placeholder="Type a message">
+            <button id="send" class="bg-blue-500 text-white px-4 py-2 rounded-r">Send</button>
+        </div>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Tailwind web UI under `moogla.web`
- serve static files from `/app` when the server starts
- package the web assets

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2376d3a48332b48b86f8c9f07f9d