### PR TITLE
Improve plugin loading error handling

### DIFF
--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -1,6 +1,9 @@
 from importlib import import_module
+import logging
 from types import ModuleType
 from typing import Callable, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Plugin:
@@ -26,6 +29,10 @@ def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
     """Import and initialize plugins from module names."""
     plugins: List[Plugin] = []
     for name in names or []:
-        module = import_module(name)
+        try:
+            module = import_module(name)
+        except Exception as exc:
+            logger.error("Failed to import plugin '%s': %s", name, exc)
+            raise ImportError(f"Cannot import plugin '{name}'") from exc
         plugins.append(Plugin(module))
     return plugins

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -1,0 +1,7 @@
+import pytest
+from moogla.server import create_app
+
+
+def test_invalid_plugin_raises_import_error():
+    with pytest.raises(ImportError):
+        create_app(["nonexistent.module"])


### PR DESCRIPTION
## Summary
- catch import failures when loading plugins
- provide a clear ImportError with log message
- test that creating an app with an unknown plugin raises ImportError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a28c773d08332a38922a617dd5470