### PR TITLE
Add dev optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ observable and developer friendly.
 1. Run the setup script to create a virtual environment and install dependencies:
 
    ```bash
-   ./scripts/setup.sh -d
+   ./scripts/setup.sh
    ```
 
-   The `-d` flag installs development tools like `pytest` and `pre-commit`.
+   When you want the development tools, install the optional extras:
+
+   ```bash
+   pip install -e .[dev]
+   ```
 
 2. After installation, run the CLI to see available commands:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ dependencies = [
     "openai>=1.30",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pre-commit",
+]
+
 [project.scripts]
 moogla = "moogla.cli:app"
 


### PR DESCRIPTION
## Summary
- provide optional development extras for `pytest` and `pre-commit`
- document installing optional extras with `pip install -e .[dev]`

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a28c1a4f883328570ae824ba5d5f0