### PR TITLE
Pin httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "fastapi>=0.110",
     "uvicorn>=0.28",
     "openai>=1.30",
+    "httpx>=0.27,<0.28",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add httpx 0.27 pin in `pyproject.toml`

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2c5607a08332bef872f5fb632324