### PR TITLE
Improve web chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ curl -X POST http://localhost:11434/v1/chat/completions \
   -d '{"messages": [{"role": "user", "content": "hello"}]}'
 ```
 
+### Web Interface
+
+To try the browser UI run the server and open the bundled web app:
+
+```bash
+moogla serve
+```
+
+Then navigate to [http://localhost:11434/app](http://localhost:11434/app).
+
 ## Contributing Guidelines
 
 - Use the `src` layout for all packages and modules.

--- a/src/moogla/web/app.js
+++ b/src/moogla/web/app.js
@@ -1,22 +1,127 @@
-async function sendMessage() {
-    const input = document.getElementById('message');
-    const text = input.value.trim();
-    if (!text) return;
-    const chat = document.getElementById('chat');
-    chat.innerHTML += `<div class="text-right mb-2"><span class="bg-blue-100 px-2 py-1 rounded">${text}</span></div>`;
-    input.value = '';
-    const resp = await fetch('/v1/chat/completions', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({messages: [{role: 'user', content: text}]})
+const chatEl = document.getElementById('chat');
+const inputEl = document.getElementById('message');
+const loadingEl = document.getElementById('loading');
+const modelSelect = document.getElementById('model');
+const pluginContainer = document.getElementById('plugin-container');
+
+const models = ['default', 'codellama:13b'];
+const plugins = ['tests.dummy_plugin'];
+let history = [];
+
+function loadModels() {
+    models.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m;
+        opt.textContent = m;
+        modelSelect.appendChild(opt);
     });
-    const data = await resp.json();
-    const reply = data.choices[0].message.content;
-    chat.innerHTML += `<div class="text-left mb-2"><span class="bg-green-100 px-2 py-1 rounded">${reply}</span></div>`;
-    chat.scrollTop = chat.scrollHeight;
+    const savedModel = localStorage.getItem('model');
+    if (savedModel) modelSelect.value = savedModel;
+    modelSelect.addEventListener('change', () => {
+        localStorage.setItem('model', modelSelect.value);
+    });
+}
+
+function loadPlugins() {
+    const saved = (localStorage.getItem('plugins') || '').split(',').filter(Boolean);
+    plugins.forEach(p => {
+        const label = document.createElement('label');
+        label.className = 'flex items-center space-x-1 text-sm';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.value = p;
+        cb.checked = saved.includes(p);
+        cb.addEventListener('change', () => {
+            const selected = Array.from(pluginContainer.querySelectorAll('input:checked')).map(el => el.value);
+            localStorage.setItem('plugins', selected.join(','));
+        });
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(p));
+        pluginContainer.appendChild(label);
+    });
+}
+
+function loadHistory() {
+    history = JSON.parse(localStorage.getItem('chatHistory') || '[]');
+    history.forEach(msg => addMessage(msg.role, msg.content));
+}
+
+function addMessage(role, text) {
+    const div = document.createElement('div');
+    div.className = `mb-2 ${role === 'user' ? 'text-right' : 'text-left'}`;
+    const span = document.createElement('span');
+    span.className = `${role === 'user' ? 'bg-blue-100' : 'bg-green-100'} px-2 py-1 rounded`;
+    span.textContent = text;
+    div.appendChild(span);
+    chatEl.appendChild(div);
+    chatEl.scrollTop = chatEl.scrollHeight;
+    return span;
+}
+
+async function sendMessage() {
+    const text = inputEl.value.trim();
+    if (!text) return;
+    const userSpan = addMessage('user', text);
+    history.push({role:'user', content:text});
+    localStorage.setItem('chatHistory', JSON.stringify(history));
+    inputEl.value = '';
+    loadingEl.classList.remove('hidden');
+    try {
+        const resp = await fetch('/v1/chat/completions', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({
+                model: modelSelect.value,
+                messages: history,
+                stream: true
+            })
+        });
+        if (resp.body && resp.headers.get('content-type')?.includes('text/event-stream')) {
+            const reader = resp.body.getReader();
+            const decoder = new TextDecoder();
+            const span = addMessage('assistant', '');
+            let buffer = '';
+            while (true) {
+                const {done, value} = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, {stream:true});
+                const lines = buffer.split('\n');
+                buffer = lines.pop();
+                for (const line of lines) {
+                    if (!line.trim()) continue;
+                    try {
+                        const data = JSON.parse(line);
+                        span.textContent += data.choices[0].delta?.content || '';
+                    } catch {
+                        span.textContent += line;
+                    }
+                    chatEl.scrollTop = chatEl.scrollHeight;
+                }
+            }
+            if (buffer.trim()) span.textContent += buffer.trim();
+            history.push({role:'assistant', content: span.textContent});
+        } else {
+            const data = await resp.json();
+            const reply = data.choices[0].message.content;
+            addMessage('assistant', reply);
+            history.push({role:'assistant', content:reply});
+        }
+    } catch (err) {
+        addMessage('assistant', 'Error: '+err.message);
+    } finally {
+        loadingEl.classList.add('hidden');
+        localStorage.setItem('chatHistory', JSON.stringify(history));
+    }
 }
 
 document.getElementById('send').addEventListener('click', sendMessage);
-document.getElementById('message').addEventListener('keypress', (e) => {
-    if (e.key === 'Enter') sendMessage();
+inputEl.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+    }
 });
+
+loadModels();
+loadPlugins();
+loadHistory();

--- a/src/moogla/web/index.html
+++ b/src/moogla/web/index.html
@@ -7,11 +7,22 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100 p-4">
-    <div class="container mx-auto max-w-xl">
-        <h1 class="text-2xl font-bold mb-4">Moogla Chat</h1>
-        <div id="chat" class="bg-white p-4 rounded shadow h-64 overflow-y-auto mb-4"></div>
+    <div class="container mx-auto max-w-xl space-y-4">
+        <h1 class="text-2xl font-bold">Moogla Chat</h1>
+
+        <div class="flex items-center space-x-2">
+            <label for="model" class="text-sm font-medium">Model:</label>
+            <select id="model" class="border rounded px-2 py-1 text-sm"></select>
+        </div>
+
+        <div id="plugin-container" class="flex items-center space-x-4"></div>
+
+        <div id="chat" class="bg-white p-4 rounded shadow h-64 overflow-y-auto"></div>
+
+        <div id="loading" class="text-center text-gray-500 hidden">Assistant is typing…</div>
+
         <div class="flex">
-            <input id="message" class="flex-grow border rounded-l px-3 py-2" type="text" placeholder="Type a message">
+            <textarea id="message" rows="2" class="flex-grow border rounded-l px-3 py-2 resize-none" placeholder="Type a message"></textarea>
             <button id="send" class="bg-blue-500 text-white px-4 py-2 rounded-r">Send</button>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance chat UI with model dropdown, plugin toggles and loading status
- implement persistent chat history and settings in localStorage
- add streaming response handling in the JS client
- document how to open the bundled web interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2ef443cc8332a5de8047cfa0237f