### PR TITLE
Fix packaging of web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ curl -X POST http://localhost:11434/v1/chat/completions \
   -d '{"messages": [{"role": "user", "content": "hello"}]}'
 ```
 
+### Web Interface
+
+After starting the server, open `http://localhost:11434/app` in your browser to
+use the simple chat UI included with the package.
+
 ## Contributing Guidelines
 
 - Use the `src` layout for all packages and modules.

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from pathlib import Path
+from importlib import resources
 from pydantic import BaseModel
 import uvicorn
 
@@ -15,9 +15,12 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
 
     app = FastAPI(title="Moogla API")
 
-    static_dir = Path(__file__).resolve().parent / "web"
-    if static_dir.exists():
-        app.mount("/app", StaticFiles(directory=static_dir, html=True), name="static")
+    try:
+        with resources.as_file(resources.files("moogla").joinpath("web")) as static_dir:
+            if static_dir.is_dir():
+                app.mount("/app", StaticFiles(directory=static_dir, html=True), name="static")
+    except FileNotFoundError:
+        pass
 
     @app.get("/health")
     def health_check():

--- a/src/moogla/web/README.md
+++ b/src/moogla/web/README.md
@@ -9,6 +9,6 @@ A reference design is available in Figma. You can duplicate it from:
 https://www.figma.com/community/file/13978200592474809/Moogla-UI-Demo
 ```
 
-To use the interface, start the Moogla server and open `index.html` in your
-browser. Messages are sent to the `/v1/chat/completions` endpoint and replies are
-displayed on the page.
+To use the interface, start the Moogla server and open
+`http://localhost:11434/app` in your browser. Messages are sent to the
+`/v1/chat/completions` endpoint and replies are displayed on the page.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from moogla.server import create_app
+
+
+def test_static_ui_served():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get('/app')
+    assert resp.status_code == 200
+    assert '<!DOCTYPE html>' in resp.text


### PR DESCRIPTION
## Summary
- include web directory as package by adding `__init__`
- mount UI using importlib resources
- document how to access the built-in web UI
- add test for `/app` static route

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2ecc51f88332be2b149f2d0682ec