### PR TITLE
Add root endpoint serving index

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from pathlib import Path
 from pydantic import BaseModel
 import uvicorn
@@ -18,6 +19,11 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
     static_dir = Path(__file__).resolve().parent / "web"
     if static_dir.exists():
         app.mount("/app", StaticFiles(directory=static_dir, html=True), name="static")
+
+        @app.get("/")
+        def root():
+            index_path = static_dir / "index.html"
+            return FileResponse(index_path)
 
     @app.get("/health")
     def health_check():

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -26,3 +26,11 @@ def test_plugins():
     resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["message"]["content"] == "!!OLLEH!!"
+
+
+def test_root_endpoint():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Moogla Chat" in resp.text


### PR DESCRIPTION
## Summary
- serve the bundled `index.html` via a new root endpoint
- test that `/` returns the web UI

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a31ed06648332a8e78f5ef589d908