### PR TITLE
Add file uploads and hint buttons to web UI

### DIFF
--- a/src/moogla/web/README.md
+++ b/src/moogla/web/README.md
@@ -2,6 +2,8 @@
 
 This folder contains a minimal web interface for interacting with a running
 Moogla server. The UI is styled using [Tailwind CSS](https://tailwindcss.com).
+It now includes optional file uploads and quick hint buttons for common
+prompts.
 
 A reference design is available in Figma. You can duplicate it from:
 

--- a/src/moogla/web/app.js
+++ b/src/moogla/web/app.js
@@ -3,9 +3,13 @@ const inputEl = document.getElementById('message');
 const loadingEl = document.getElementById('loading');
 const modelSelect = document.getElementById('model');
 const pluginContainer = document.getElementById('plugin-container');
+const fileInput = document.getElementById('file-input');
+const hintsContainer = document.getElementById('hints');
+const clearBtn = document.getElementById('clear-chat');
 
 const models = ['default', 'codellama:13b'];
 const plugins = ['tests.dummy_plugin'];
+const hints = ['Summarize the text', 'List key points', 'Explain it simply'];
 let history = [];
 
 function loadModels() {
@@ -41,6 +45,19 @@ function loadPlugins() {
     });
 }
 
+function loadHints() {
+    hints.forEach(h => {
+        const btn = document.createElement('button');
+        btn.textContent = h;
+        btn.className = 'text-xs bg-gray-200 px-2 py-1 rounded';
+        btn.addEventListener('click', () => {
+            inputEl.value = h;
+            inputEl.focus();
+        });
+        hintsContainer.appendChild(btn);
+    });
+}
+
 function loadHistory() {
     history = JSON.parse(localStorage.getItem('chatHistory') || '[]');
     history.forEach(msg => addMessage(msg.role, msg.content));
@@ -58,8 +75,8 @@ function addMessage(role, text) {
     return span;
 }
 
-async function sendMessage() {
-    const text = inputEl.value.trim();
+async function sendMessage(textOverride) {
+    const text = (textOverride ?? inputEl.value).trim();
     if (!text) return;
     const userSpan = addMessage('user', text);
     history.push({role:'user', content:text});
@@ -122,6 +139,22 @@ inputEl.addEventListener('keypress', (e) => {
     }
 });
 
+fileInput.addEventListener('change', async () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    const text = await file.text();
+    addMessage('user', `[Uploaded: ${file.name}]`);
+    await sendMessage(text);
+    fileInput.value = '';
+});
+
+clearBtn.addEventListener('click', () => {
+    history = [];
+    localStorage.removeItem('chatHistory');
+    chatEl.innerHTML = '';
+});
+
 loadModels();
 loadPlugins();
 loadHistory();
+loadHints();

--- a/src/moogla/web/index.html
+++ b/src/moogla/web/index.html
@@ -17,6 +17,14 @@
 
         <div id="plugin-container" class="flex items-center space-x-4"></div>
 
+        <div class="flex items-center space-x-2">
+            <label for="file-input" class="text-sm font-medium">Upload file:</label>
+            <input id="file-input" type="file" class="text-sm" />
+            <button id="clear-chat" class="ml-auto text-xs text-red-500">Clear Chat</button>
+        </div>
+
+        <div id="hints" class="flex flex-wrap gap-2"></div>
+
         <div id="chat" class="bg-white p-4 rounded shadow h-64 overflow-y-auto"></div>
 
         <div id="loading" class="text-center text-gray-500 hidden">Assistant is typing…</div>


### PR DESCRIPTION
## Summary
- add file upload and clear chat controls to `index.html`
- implement hint buttons and file upload handling in `app.js`
- document the new features in the web interface README

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3295fd908332b2a9fae5f6acb312