### PR TITLE
Add endpoint and CLI documentation

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -14,13 +14,25 @@ def serve(
         None, '--plugin', '-p', help='Plugin module to load', show_default=False
     ),
 ):
-    """Start the Moogla HTTP server."""
+    """Start the Moogla HTTP server.
+
+    Parameters
+    ----------
+    host: IP or hostname to bind.
+    port: TCP port to listen on.
+    plugin: Optional plugin modules to initialize.
+    """
     start_server(host=host, port=port, plugin_names=plugin)
 
 
 @app.command()
 def pull(model: str):
-    """Pull a model into the local cache (stub)."""
+    """Download a model into the local cache (stub).
+
+    Parameters
+    ----------
+    model: Identifier of the model to fetch.
+    """
     typer.echo(f"Pulling {model} ... done.")
 
 if __name__ == "__main__":

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -22,11 +22,13 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
 
         @app.get("/")
         def root():
+            """Serve the bundled web UI index page."""
             index_path = static_dir / "index.html"
             return FileResponse(index_path)
 
     @app.get("/health")
     def health_check():
+        """Return a simple heartbeat response for monitoring."""
         return {"status": "ok"}
 
     class Message(BaseModel):
@@ -42,6 +44,7 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
         stream: bool = False
 
     def apply_plugins(text: str) -> str:
+        """Run text through plugin hooks and return the mock LLM output."""
         for plugin in plugins:
             text = plugin.run_preprocess(text)
         response = text[::-1]  # mock generation
@@ -51,6 +54,7 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
 
     @app.post("/v1/chat/completions")
     def chat_completions(req: ChatRequest):
+        """Handle Chat API calls and return a reversed assistant reply."""
         if not req.messages:
             return {"choices": []}
         content = req.messages[-1].content
@@ -59,6 +63,7 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
 
     @app.post("/v1/completions")
     def completions(req: CompletionRequest):
+        """Return a completion for the given prompt using the mock backend."""
         reply = apply_plugins(req.prompt)
         return {"choices": [{"text": reply}]}
 


### PR DESCRIPTION
## Summary
- document CLI commands with docstrings
- add docstrings for key server endpoints and helper function

## Testing
- `pip install typer fastapi uvicorn openai httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a422887048332bdae661067135afb