### PR TITLE
Use executor for completions

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,8 @@
+import os
 from fastapi.testclient import TestClient
 from moogla.server import create_app
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 client = TestClient(create_app())
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,9 +1,19 @@
+import os
 from fastapi.testclient import TestClient
 
+from moogla import server
 from moogla.server import create_app
 
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
-def test_chat_completion():
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+def test_chat_completion(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app()
     client = TestClient(app)
     resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})
@@ -12,7 +22,8 @@ def test_chat_completion():
     assert data["choices"][0]["message"]["content"] == "olleh"
 
 
-def test_completion_endpoint():
+def test_completion_endpoint(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app()
     client = TestClient(app)
     resp = client.post("/v1/completions", json={"prompt": "abc"})
@@ -20,7 +31,8 @@ def test_completion_endpoint():
     assert resp.json()["choices"][0]["text"] == "cba"
 
 
-def test_plugins():
+def test_plugins(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app(["tests.dummy_plugin"])
     client = TestClient(app)
     resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -1,5 +1,8 @@
+import os
 import pytest
 from moogla.server import create_app
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 
 def test_invalid_plugin_raises_import_error():


### PR DESCRIPTION
## Summary
- generate text using `LLMExecutor` in the HTTP server
- pass model and API parameters to `start_server`
- adjust endpoint tests to mock the executor
- set dummy API key for other tests

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4229b3748332840680b299dc1658