### PR TITLE
Add async streaming OpenAI endpoints

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -1,18 +1,24 @@
-from typing import List, Optional
+from typing import List, Optional, AsyncIterable
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pathlib import Path
 from pydantic import BaseModel
 import uvicorn
 
+import openai
+
 from .plugins import Plugin, load_plugins
 
 
-def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
+def create_app(
+    plugin_names: Optional[List[str]] = None,
+    openai_client: Optional[openai.AsyncOpenAI] = None,
+) -> FastAPI:
     """Build the FastAPI application."""
     plugins = load_plugins(plugin_names)
+    openai_client = openai_client or openai.AsyncOpenAI()
 
     app = FastAPI(title="Moogla API")
 
@@ -41,25 +47,51 @@ def create_app(plugin_names: Optional[List[str]] = None) -> FastAPI:
         prompt: str
         stream: bool = False
 
-    def apply_plugins(text: str) -> str:
+    async def apply_plugins(text: str) -> str:
         for plugin in plugins:
             text = plugin.run_preprocess(text)
-        response = text[::-1]  # mock generation
+        resp = await openai_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": text}],
+        )
+        response = resp.choices[0].message.content
         for plugin in plugins:
             response = plugin.run_postprocess(response)
         return response
 
     @app.post("/v1/chat/completions")
-    def chat_completions(req: ChatRequest):
+    async def chat_completions(req: ChatRequest):
         if not req.messages:
             return {"choices": []}
         content = req.messages[-1].content
-        reply = apply_plugins(content)
+        if req.stream:
+            async def generator() -> AsyncIterable[str]:
+                async for chunk in await openai_client.chat.completions.create(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": content}],
+                    stream=True,
+                ):
+                    yield chunk.choices[0].delta.content or ""
+
+            return StreamingResponse(generator(), media_type="text/plain")
+
+        reply = await apply_plugins(content)
         return {"choices": [{"message": {"role": "assistant", "content": reply}}]}
 
     @app.post("/v1/completions")
-    def completions(req: CompletionRequest):
-        reply = apply_plugins(req.prompt)
+    async def completions(req: CompletionRequest):
+        if req.stream:
+            async def generator() -> AsyncIterable[str]:
+                async for chunk in await openai_client.completions.create(
+                    model="gpt-3.5-turbo",
+                    prompt=req.prompt,
+                    stream=True,
+                ):
+                    yield chunk.choices[0].text
+
+            return StreamingResponse(generator(), media_type="text/plain")
+
+        reply = await apply_plugins(req.prompt)
         return {"choices": [{"text": reply}]}
 
     return app

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,9 +1,26 @@
+import types
+import openai
 from fastapi.testclient import TestClient
 from moogla.server import create_app
 
-client = TestClient(create_app())
 
-def test_health_check():
+class DummyAsyncChat:
+    async def create(self, model, messages=None, prompt=None, stream=False):
+        text = messages[-1]["content"] if messages else prompt
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=text))]
+        )
+
+
+class DummyAsyncOpenAI:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=DummyAsyncChat())
+        self.completions = DummyAsyncChat()
+
+
+def test_health_check(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    client = TestClient(create_app(openai_client=DummyAsyncOpenAI()))
     resp = client.get('/health')
     assert resp.status_code == 200
     assert resp.json() == {'status': 'ok'}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,10 +1,43 @@
+import types
+import openai
 from fastapi.testclient import TestClient
 
 from moogla.server import create_app
 
 
-def test_chat_completion():
-    app = create_app()
+class DummyAsyncChat:
+    async def create(self, model, messages=None, prompt=None, stream=False):
+        text = messages[-1]["content"] if messages else prompt
+        reversed_text = text[::-1]
+        if stream:
+            async def gen():
+                for ch in reversed_text:
+                    yield types.SimpleNamespace(
+                        choices=[types.SimpleNamespace(
+                            delta=types.SimpleNamespace(content=ch),
+                            text=ch,
+                        )]
+                    )
+            return gen()
+        return types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content=reversed_text),
+                    text=reversed_text,
+                )
+            ]
+        )
+
+
+class DummyAsyncOpenAI:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=DummyAsyncChat())
+        self.completions = DummyAsyncChat()
+
+
+def test_chat_completion(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    app = create_app(openai_client=DummyAsyncOpenAI())
     client = TestClient(app)
     resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})
     assert resp.status_code == 200
@@ -12,25 +45,52 @@ def test_chat_completion():
     assert data["choices"][0]["message"]["content"] == "olleh"
 
 
-def test_completion_endpoint():
-    app = create_app()
+def test_completion_endpoint(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    app = create_app(openai_client=DummyAsyncOpenAI())
     client = TestClient(app)
     resp = client.post("/v1/completions", json={"prompt": "abc"})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["text"] == "cba"
 
 
-def test_plugins():
-    app = create_app(["tests.dummy_plugin"])
+def test_plugins(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    app = create_app(["tests.dummy_plugin"], openai_client=DummyAsyncOpenAI())
     client = TestClient(app)
     resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hello"}]})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["message"]["content"] == "!!OLLEH!!"
 
 
-def test_root_endpoint():
-    app = create_app()
+def test_root_endpoint(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    app = create_app(openai_client=DummyAsyncOpenAI())
     client = TestClient(app)
     resp = client.get("/")
     assert resp.status_code == 200
     assert "Moogla Chat" in resp.text
+
+
+def test_streaming_chat(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    app = create_app(openai_client=DummyAsyncOpenAI())
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
+    )
+    assert resp.status_code == 200
+    assert resp.text == "ih"
+
+
+def test_streaming_completion(monkeypatch):
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: DummyAsyncOpenAI())
+    app = create_app(openai_client=DummyAsyncOpenAI())
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/completions",
+        json={"prompt": "abc", "stream": True},
+    )
+    assert resp.status_code == 200
+    assert resp.text == "cba"

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -1,7 +1,20 @@
 import pytest
+import openai
+import types
 from moogla.server import create_app
+
+
+class DummyAsyncChat:
+    async def create(self, model, messages=None, prompt=None, stream=False):
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=""))])
+
+
+class DummyAsyncOpenAI:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=DummyAsyncChat())
+        self.completions = DummyAsyncChat()
 
 
 def test_invalid_plugin_raises_import_error():
     with pytest.raises(ImportError):
-        create_app(["nonexistent.module"])
+        create_app(["nonexistent.module"], openai_client=DummyAsyncOpenAI())


### PR DESCRIPTION
## Summary
- make chat and completion endpoints async
- support streaming responses
- allow injecting a custom OpenAI client for testing
- add tests for streaming mode and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a422b0ae48332a9ebc90460839c1e