### PR TITLE
Add CLI serve test and plugin error handling coverage

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
 from typer.testing import CliRunner
+from fastapi.testclient import TestClient
 from moogla.cli import app
+from moogla import server
+import types
 
 runner = CliRunner()
 
@@ -13,3 +16,20 @@ def test_pull():
     result = runner.invoke(app, ['pull', 'test-model'])
     assert result.exit_code == 0
     assert 'Pulling test-model ... done.' in result.output
+
+
+def test_serve_with_plugin(monkeypatch):
+    captured = {}
+
+    def fake_run(app, host='0.0.0.0', port=11434):
+        captured['app'] = app
+
+    monkeypatch.setattr(server, 'uvicorn', types.SimpleNamespace(run=fake_run))
+
+    result = runner.invoke(app, ['serve', '--plugin', 'tests.dummy_plugin'])
+    assert result.exit_code == 0
+
+    client = TestClient(captured['app'])
+    resp = client.post('/v1/completions', json={'prompt': 'abc'})
+    assert resp.status_code == 200
+    assert resp.json()['choices'][0]['text'] == '!!CBA!!'

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -1,7 +1,40 @@
 import pytest
 from moogla.server import create_app
+from fastapi.testclient import TestClient
+import sys
+import types
 
 
 def test_invalid_plugin_raises_import_error():
     with pytest.raises(ImportError):
         create_app(["nonexistent.module"])
+
+
+def test_preprocess_exception_results_in_500():
+    mod = types.ModuleType('error_pre_plugin')
+
+    def preprocess(text: str) -> str:
+        raise RuntimeError('fail')
+
+    mod.preprocess = preprocess
+    sys.modules['error_pre_plugin'] = mod
+    app = create_app(['error_pre_plugin'])
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post('/v1/completions', json={'prompt': 'abc'})
+    assert resp.status_code == 500
+    sys.modules.pop('error_pre_plugin', None)
+
+
+def test_postprocess_exception_results_in_500():
+    mod = types.ModuleType('error_post_plugin')
+
+    def postprocess(text: str) -> str:
+        raise RuntimeError('boom')
+
+    mod.postprocess = postprocess
+    sys.modules['error_post_plugin'] = mod
+    app = create_app(['error_post_plugin'])
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post('/v1/completions', json={'prompt': 'abc'})
+    assert resp.status_code == 500
+    sys.modules.pop('error_post_plugin', None)


### PR DESCRIPTION
## Summary
- test CLI `serve` command with plugin using `TestClient`
- add plugin error tests for preprocess and postprocess

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a422beaac83329bcab39356a05099