### PR TITLE
Convert server to async

### DIFF
--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -13,11 +13,22 @@ class LLMExecutor:
 
     def __init__(self, model: str, api_key: Optional[str] = None, api_base: Optional[str] = None) -> None:
         self.model = model
-        self.client = openai.OpenAI(api_key=api_key or os.getenv("OPENAI_API_KEY"), base_url=api_base)
+        key = api_key or os.getenv("OPENAI_API_KEY")
+        self.client = openai.OpenAI(api_key=key, base_url=api_base)
+        self.async_client = openai.AsyncOpenAI(api_key=key, base_url=api_base)
 
     def complete(self, prompt: str, *, max_tokens: int = 16) -> str:
         """Return a completion for the given prompt."""
         response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+        )
+        return response.choices[0].message.content
+
+    async def acomplete(self, prompt: str, *, max_tokens: int = 16) -> str:
+        """Asynchronously return a completion for the given prompt."""
+        response = await self.async_client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -2,6 +2,7 @@ from importlib import import_module
 import logging
 from types import ModuleType
 from typing import Callable, List, Optional
+import inspect
 
 logger = logging.getLogger(__name__)
 
@@ -14,13 +15,17 @@ class Plugin:
         self.preprocess: Optional[Callable[[str], str]] = getattr(module, "preprocess", None)
         self.postprocess: Optional[Callable[[str], str]] = getattr(module, "postprocess", None)
 
-    def run_preprocess(self, text: str) -> str:
+    async def run_preprocess(self, text: str) -> str:
         if self.preprocess:
+            if inspect.iscoroutinefunction(self.preprocess):
+                return await self.preprocess(text)
             return self.preprocess(text)
         return text
 
-    def run_postprocess(self, text: str) -> str:
+    async def run_postprocess(self, text: str) -> str:
         if self.postprocess:
+            if inspect.iscoroutinefunction(self.postprocess):
+                return await self.postprocess(text)
             return self.postprocess(text)
         return text
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,12 @@ def test_serve_with_plugin(monkeypatch):
 
     monkeypatch.setattr(server, 'uvicorn', types.SimpleNamespace(run=fake_run))
 
+    class DummyExecutor:
+        async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+            return prompt[::-1]
+
+    monkeypatch.setattr(server, 'LLMExecutor', lambda *a, **kw: DummyExecutor())
+
     result = runner.invoke(app, ['serve', '--plugin', 'tests.dummy_plugin'])
     assert result.exit_code == 0
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -19,6 +19,7 @@ class DummyClient:
 def test_complete(monkeypatch):
     dummy = DummyClient()
     monkeypatch.setattr(openai, "OpenAI", lambda api_key=None, base_url=None: dummy)
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda api_key=None, base_url=None: dummy)
     executor = LLMExecutor(model="gpt-3.5-turbo")
     result = executor.complete("hello")
     assert result == "hi"


### PR DESCRIPTION
## Summary
- support async plugin hooks
- expose `LLMExecutor.acomplete`
- update FastAPI endpoints to async
- adjust tests for async interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4f3deedc8332bf245d49df05899b