### PR TITLE
Add caching to LLM executor

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -13,6 +13,12 @@ def serve(
     plugin: List[str] = typer.Option(
         None, '--plugin', '-p', help='Plugin module to load', show_default=False
     ),
+    cache_size: int = typer.Option(
+        None,
+        '--cache-size',
+        help='Maximum number of prompts to cache',
+        show_default=False,
+    ),
 ):
     """Start the Moogla HTTP server.
 
@@ -21,8 +27,9 @@ def serve(
     host: IP or hostname to bind.
     port: TCP port to listen on.
     plugin: Optional plugin modules to initialize.
+    cache_size: Size of the completion cache.
     """
-    start_server(host=host, port=port, plugin_names=plugin)
+    start_server(host=host, port=port, plugin_names=plugin, cache_size=cache_size)
 
 
 @app.command()

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -4,22 +4,41 @@ from __future__ import annotations
 
 from typing import Optional
 import os
+from functools import lru_cache
 
 import openai
 
 
 class LLMExecutor:
-    """Simple wrapper around the OpenAI client."""
+    """Simple wrapper around the OpenAI client with optional caching."""
 
-    def __init__(self, model: str, api_key: Optional[str] = None, api_base: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        cache_size: Optional[int] = None,
+    ) -> None:
         self.model = model
-        self.client = openai.OpenAI(api_key=api_key or os.getenv("OPENAI_API_KEY"), base_url=api_base)
+        self.client = openai.OpenAI(
+            api_key=api_key or os.getenv("OPENAI_API_KEY"),
+            base_url=api_base,
+        )
 
-    def complete(self, prompt: str, *, max_tokens: int = 16) -> str:
-        """Return a completion for the given prompt."""
+        if cache_size is None:
+            cache_size_env = os.getenv("MOOGLA_CACHE_SIZE")
+            cache_size = int(cache_size_env) if cache_size_env else 128
+
+        self._complete_cached = lru_cache(maxsize=cache_size)(self._complete)
+
+    def _complete(self, prompt: str, max_tokens: int) -> str:
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,
         )
         return response.choices[0].message.content
+
+    def complete(self, prompt: str, *, max_tokens: int = 16) -> str:
+        """Return a completion for the given prompt."""
+        return self._complete_cached(prompt, max_tokens)

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -18,6 +18,7 @@ def create_app(
     model: Optional[str] = None,
     api_key: Optional[str] = None,
     api_base: Optional[str] = None,
+    cache_size: Optional[int] = None,
 ) -> FastAPI:
     """Build the FastAPI application."""
     plugins = load_plugins(plugin_names)
@@ -26,7 +27,16 @@ def create_app(
     api_key = api_key or os.getenv("OPENAI_API_KEY")
     api_base = api_base or os.getenv("OPENAI_API_BASE")
 
-    executor = LLMExecutor(model=model, api_key=api_key, api_base=api_base)
+    if cache_size is None:
+        cache_env = os.getenv("MOOGLA_CACHE_SIZE")
+        cache_size = int(cache_env) if cache_env else None
+
+    executor = LLMExecutor(
+        model=model,
+        api_key=api_key,
+        api_base=api_base,
+        cache_size=cache_size,
+    )
 
     app = FastAPI(title="Moogla API")
 
@@ -91,6 +101,7 @@ def start_server(
     model: Optional[str] = None,
     api_key: Optional[str] = None,
     api_base: Optional[str] = None,
+    cache_size: Optional[int] = None,
 ) -> None:
     """Run the HTTP server."""
     app = create_app(
@@ -98,5 +109,6 @@ def start_server(
         model=model,
         api_key=api_key,
         api_base=api_base,
+        cache_size=cache_size,
     )
     uvicorn.run(app, host=host, port=port)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,11 @@ from moogla.cli import app
 from moogla import server
 import types
 
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
 runner = CliRunner()
 
 def test_help():
@@ -25,6 +30,7 @@ def test_serve_with_plugin(monkeypatch):
         captured['app'] = app
 
     monkeypatch.setattr(server, 'uvicorn', types.SimpleNamespace(run=fake_run))
+    monkeypatch.setattr(server, 'LLMExecutor', lambda *a, **kw: DummyExecutor())
 
     result = runner.invoke(app, ['serve', '--plugin', 'tests.dummy_plugin'])
     assert result.exit_code == 0

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -16,9 +16,44 @@ class DummyClient:
         )
 
 
+class CountingClient(DummyClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def create(self, model, messages, max_tokens):
+        self.calls += 1
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=messages[0]["content"]))]
+        )
+
+
 def test_complete(monkeypatch):
     dummy = DummyClient()
     monkeypatch.setattr(openai, "OpenAI", lambda api_key=None, base_url=None: dummy)
     executor = LLMExecutor(model="gpt-3.5-turbo")
     result = executor.complete("hello")
     assert result == "hi"
+
+
+def test_cache_hit(monkeypatch):
+    client = CountingClient()
+    monkeypatch.setattr(openai, "OpenAI", lambda api_key=None, base_url=None: client)
+    executor = LLMExecutor(model="gpt-3.5-turbo", cache_size=2)
+    assert executor.complete("foo") == "foo"
+    assert client.calls == 1
+    # Second call should hit cache
+    assert executor.complete("foo") == "foo"
+    assert client.calls == 1
+
+
+def test_cache_eviction(monkeypatch):
+    client = CountingClient()
+    monkeypatch.setattr(openai, "OpenAI", lambda api_key=None, base_url=None: client)
+    executor = LLMExecutor(model="gpt-3.5-turbo", cache_size=1)
+    executor.complete("a")
+    executor.complete("b")
+    assert client.calls == 2
+    # "a" should be evicted from cache
+    executor.complete("a")
+    assert client.calls == 3


### PR DESCRIPTION
## Summary
- add optional caching layer in `LLMExecutor`
- expose `--cache-size` option on the CLI
- pipe cache size through server
- update CLI tests to avoid real network calls
- add unit tests exercising cache hits and evictions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4f3e899883328f4492c23c9fbf11