### PR TITLE
Add entry point plugin discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ moogla pull codellama:13b
 moogla serve --plugin tests.dummy_plugin
 ```
 
+Plugins can also be distributed as separate packages by exposing the
+`moogla.plugins` entry point. A minimal `pyproject.toml` might look like:
+
+```toml
+[project.entry-points."moogla.plugins"]
+example = "my_plugin.module"
+```
+
+After installing the package, the plugin will be picked up automatically
+without passing `--plugin` on the command line.
+
 You can then query the chat completion endpoint:
 
 ```bash

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -1,4 +1,4 @@
-from importlib import import_module
+from importlib import import_module, metadata
 import logging
 from types import ModuleType
 from typing import Callable, List, Optional
@@ -26,8 +26,10 @@ class Plugin:
 
 
 def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
-    """Import and initialize plugins from module names."""
+    """Import and initialize plugins from module names and entry points."""
     plugins: List[Plugin] = []
+    loaded: set[str] = set()
+
     for name in names or []:
         try:
             module = import_module(name)
@@ -35,4 +37,22 @@ def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
             logger.error("Failed to import plugin '%s': %s", name, exc)
             raise ImportError(f"Cannot import plugin '{name}'") from exc
         plugins.append(Plugin(module))
+        loaded.add(module.__name__)
+
+    try:
+        entries = metadata.entry_points(group="moogla.plugins")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to read entry points: %s", exc)
+        entries = []
+
+    for ep in entries:
+        try:
+            module = ep.load()
+        except Exception as exc:
+            logger.error("Failed to load plugin '%s': %s", ep.value, exc)
+            raise ImportError(f"Cannot load plugin '{ep.value}'") from exc
+        if module.__name__ not in loaded:
+            plugins.append(Plugin(module))
+            loaded.add(module.__name__)
+
     return plugins

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,10 @@ from typer.testing import CliRunner
 from fastapi.testclient import TestClient
 from moogla.cli import app
 from moogla import server
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
 import types
 
 runner = CliRunner()
@@ -25,6 +29,7 @@ def test_serve_with_plugin(monkeypatch):
         captured['app'] = app
 
     monkeypatch.setattr(server, 'uvicorn', types.SimpleNamespace(run=fake_run))
+    monkeypatch.setattr(server, 'LLMExecutor', lambda *a, **kw: DummyExecutor())
 
     result = runner.invoke(app, ['serve', '--plugin', 'tests.dummy_plugin'])
     assert result.exit_code == 0

--- a/tests/test_plugin_entrypoints.py
+++ b/tests/test_plugin_entrypoints.py
@@ -1,0 +1,30 @@
+import os
+from fastapi.testclient import TestClient
+from importlib import metadata
+from moogla import server
+from moogla.server import create_app
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+def test_entrypoint_plugin_loaded(monkeypatch):
+    ep = metadata.EntryPoint(
+        name="dummy", value="tests.dummy_plugin", group="moogla.plugins"
+    )
+
+    def fake_entry_points(*, group=None):
+        if group == "moogla.plugins":
+            return metadata.EntryPoints((ep,))
+        return metadata.EntryPoints(())
+
+    monkeypatch.setattr(metadata, "entry_points", fake_entry_points)
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "!!CBA!!"


### PR DESCRIPTION
## Summary
- discover plugins via `importlib.metadata.entry_points`
- document `moogla.plugins` entry point in the README
- ensure CLI tests use DummyExecutor
- add tests verifying entry point plugin loading

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4f3f7ef483329032bc20bf46b285