### PR TITLE
Add Docker deployment files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to ghcr
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir .
+EXPOSE 11434
+CMD ["moogla", "serve"]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ Then navigate to [http://localhost:11434/app](http://localhost:11434/app).
 Double‑click a chat bubble to copy its contents and use the dark‑mode toggle in
 the header to switch themes.
 
+## Running with Docker
+
+Build the image and start the server:
+
+```bash
+docker build -t moogla .
+docker run -p 11434:11434 moogla
+```
+
+You can also use `docker-compose` to mount a models directory and supply
+environment variables:
+
+```bash
+docker-compose up
+```
+
+
 ## Contributing Guidelines
 
 - Use the `src` layout for all packages and modules.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  moogla:
+    build: .
+    ports:
+      - "11434:11434"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - MOOGLA_MODEL=codellama:13b
+    volumes:
+      - ./models:/models

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from typer.testing import CliRunner
 from fastapi.testclient import TestClient
 from moogla.cli import app
 from moogla import server
+import openai
 import types
 
 runner = CliRunner()
@@ -24,7 +25,18 @@ def test_serve_with_plugin(monkeypatch):
     def fake_run(app, host='0.0.0.0', port=11434):
         captured['app'] = app
 
+    class DummyClient:
+        def __init__(self, content: str = "HI") -> None:
+            self.content = content
+            self.chat = types.SimpleNamespace(completions=self)
+
+        def create(self, model, messages, max_tokens):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=self.content))]
+            )
+
     monkeypatch.setattr(server, 'uvicorn', types.SimpleNamespace(run=fake_run))
+    monkeypatch.setattr(openai, 'OpenAI', lambda api_key=None, base_url=None: DummyClient("CBA"))
 
     result = runner.invoke(app, ['serve', '--plugin', 'tests.dummy_plugin'])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add Dockerfile exposing the serve command
- document Docker usage in README
- include docker-compose example with env vars & volume mount
- patch tests to avoid network calls to OpenAI
- add GitHub action to build and publish image

## Testing
- `pip install -e .[dev]`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4f416d348332afde262fd68ca9cf