### PR TITLE
Implement model pull command

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -1,4 +1,9 @@
 from typing import List
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
 
 import typer
 
@@ -25,15 +30,60 @@ def serve(
     start_server(host=host, port=port, plugin_names=plugin)
 
 
+DEFAULT_DIR = Path.home() / ".cache" / "moogla" / "models"
+
+
 @app.command()
-def pull(model: str):
-    """Download a model into the local cache (stub).
+def pull(
+    model: str,
+    dir: Path = typer.Option(None, "--dir", "-d", help="Directory for downloaded models"),
+):
+    """Download a model into the local cache.
 
     Parameters
     ----------
-    model: Identifier of the model to fetch.
+    model: Identifier, path or URL of the model to fetch.
+    dir: Target directory for the downloaded file.
     """
-    typer.echo(f"Pulling {model} ... done.")
+    dest_dir = dir or Path(os.getenv("MOOGLA_MODEL_DIR", DEFAULT_DIR))
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    parsed = urlparse(model)
+    filename = Path(parsed.path).name or "model"
+    dest = dest_dir / filename
+
+    if dest.exists():
+        typer.echo(f"Using cached model at {dest}")
+        return
+
+    if parsed.scheme in {"http", "https", "file"}:
+        url = model
+        with httpx.stream("GET", url) as resp:
+            resp.raise_for_status()
+            total = int(resp.headers.get("content-length", 0))
+            with open(dest, "wb") as f, typer.progressbar(
+                length=total or None, label="Downloading"
+            ) as bar:
+                for chunk in resp.iter_bytes():
+                    f.write(chunk)
+                    if total:
+                        bar.update(len(chunk))
+    elif Path(model).is_file():
+        size = os.path.getsize(model)
+        with open(model, "rb") as src, open(dest, "wb") as dst, typer.progressbar(
+            length=size, label="Downloading"
+        ) as bar:
+            while True:
+                data = src.read(8192)
+                if not data:
+                    break
+                dst.write(data)
+                bar.update(len(data))
+    else:
+        typer.echo(f"Unknown model source: {model}")
+        raise typer.Exit(code=1)
+
+    typer.echo(f"\nSaved to {dest}")
 
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,10 +13,15 @@ def test_help():
     assert 'serve' in result.output
     assert 'pull' in result.output
 
-def test_pull():
-    result = runner.invoke(app, ['pull', 'test-model'])
+def test_pull(tmp_path):
+    src = tmp_path / "model.bin"
+    src.write_text("data")
+    dest_dir = tmp_path / "models"
+    result = runner.invoke(app, ["pull", str(src), "--dir", str(dest_dir)])
     assert result.exit_code == 0
-    assert 'Pulling test-model ... done.' in result.output
+    dest = dest_dir / "model.bin"
+    assert dest.exists()
+    assert dest.read_text() == "data"
 
 
 def test_serve_with_plugin(monkeypatch):


### PR DESCRIPTION
## Summary
- add real download logic to `moogla pull`
- allow configurable model directory and handle cached files
- use progress output for downloads
- test that the pull command writes files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad0a84b4c833299f7cef01ae4d308