### PR TITLE
Improve plugin error handling

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -2,15 +2,18 @@ from typing import List, Optional
 
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pathlib import Path
 from pydantic import BaseModel
 import uvicorn
+import logging
 
 from .plugins import Plugin, load_plugins
 from .executor import LLMExecutor
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(
@@ -60,10 +63,18 @@ def create_app(
     async def apply_plugins(text: str) -> str:
         """Run text through plugin hooks and return the mock LLM output."""
         for plugin in plugins:
-            text = await plugin.run_preprocess(text)
+            try:
+                text = await plugin.run_preprocess(text)
+            except Exception as exc:
+                logger.exception("Preprocess plugin failed: %s", exc)
+                raise HTTPException(status_code=500, detail="Plugin error") from exc
         response = await executor.acomplete(text)
         for plugin in plugins:
-            response = await plugin.run_postprocess(response)
+            try:
+                response = await plugin.run_postprocess(response)
+            except Exception as exc:
+                logger.exception("Postprocess plugin failed: %s", exc)
+                raise HTTPException(status_code=500, detail="Plugin error") from exc
         return response
 
     @app.post("/v1/chat/completions")

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -34,6 +34,7 @@ def test_preprocess_exception_results_in_500(monkeypatch):
     client = TestClient(app, raise_server_exceptions=False)
     resp = client.post('/v1/completions', json={'prompt': 'abc'})
     assert resp.status_code == 500
+    assert resp.json()["detail"] == "Plugin error"
     sys.modules.pop('error_pre_plugin', None)
 
 
@@ -50,4 +51,5 @@ def test_postprocess_exception_results_in_500(monkeypatch):
     client = TestClient(app, raise_server_exceptions=False)
     resp = client.post('/v1/completions', json={'prompt': 'abc'})
     assert resp.status_code == 500
+    assert resp.json()["detail"] == "Plugin error"
     sys.modules.pop('error_post_plugin', None)


### PR DESCRIPTION
## Summary
- catch plugin exceptions in `apply_plugins`
- log plugin errors and return `HTTPException`
- test for new `Plugin error` message in plugin error tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad0a97ee8833285fdf4deb1859e47