### PR TITLE
Add configuration loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ curl -X POST http://localhost:11434/v1/chat/completions \
   -d '{"messages": [{"role": "user", "content": "hello"}]}'
 ```
 
+### Configuration
+
+Settings can be stored in a `config.toml` file placed next to the
+application. A sample is provided as `config.example.toml`:
+
+```toml
+model = "gpt-3.5-turbo"
+# api_key = "sk-..."
+# api_base = "https://api.openai.com/v1"
+```
+
+Environment variables such as `MOOGLA_MODEL`, `OPENAI_API_KEY` and
+`OPENAI_API_BASE` override the values from the file.
+
 ## Development Setup
 
 The project uses [Typer](https://typer.tiangolo.com/) for the CLI and

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,6 @@
+# Example Moogla configuration file
+# Copy to config.toml and adjust as needed
+
+model = "gpt-3.5-turbo"
+# api_key = "sk-..."
+# api_base = "https://api.openai.com/v1"

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -2,6 +2,8 @@ from typing import List
 
 import typer
 
+from .config import load_config
+
 from .server import start_server
 
 app = typer.Typer(help="Moogla command line interface")
@@ -13,6 +15,9 @@ def serve(
     plugin: List[str] = typer.Option(
         None, '--plugin', '-p', help='Plugin module to load', show_default=False
     ),
+    config: str = typer.Option(
+        None, '--config', '-c', help='Path to configuration file', show_default=False
+    ),
 ):
     """Start the Moogla HTTP server.
 
@@ -22,7 +27,8 @@ def serve(
     port: TCP port to listen on.
     plugin: Optional plugin modules to initialize.
     """
-    start_server(host=host, port=port, plugin_names=plugin)
+    cfg = load_config(config)
+    start_server(host=host, port=port, plugin_names=plugin, config=cfg)
 
 
 @app.command()

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import tomllib
+from typing import Optional
+
+@dataclass
+class Config:
+    """Runtime configuration parameters."""
+
+    model: str = "gpt-3.5-turbo"
+    api_key: Optional[str] = None
+    api_base: Optional[str] = None
+
+
+def load_config(path: Optional[str | Path] = None) -> Config:
+    """Load configuration from ``path`` and merge environment variables."""
+    file_path = Path(os.getenv("MOOGLA_CONFIG", path or "config.toml"))
+    data: dict[str, object] = {}
+    if file_path.is_file():
+        with open(file_path, "rb") as fh:
+            data = tomllib.load(fh)
+
+    cfg_dict = {
+        "model": "gpt-3.5-turbo",
+        "api_key": None,
+        "api_base": None,
+        **data,
+    }
+
+    overrides = {
+        "model": os.getenv("MOOGLA_MODEL"),
+        "api_key": os.getenv("OPENAI_API_KEY"),
+        "api_base": os.getenv("OPENAI_API_BASE"),
+    }
+    for key, value in overrides.items():
+        if value is not None:
+            cfg_dict[key] = value
+
+    return Config(**cfg_dict)


### PR DESCRIPTION
## Summary
- add simple TOML configuration loader
- integrate configuration with server and CLI
- include sample `config.example.toml`
- document how to use configuration in README

## Testing
- `pip install -e .[dev]`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad0aab81c83328e7d695496e2e5f8