### PR TITLE
Implement streaming responses for endpoints

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -4,10 +4,11 @@ import os
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pathlib import Path
 from pydantic import BaseModel
 import uvicorn
+import json
 
 from .plugins import Plugin, load_plugins
 from .executor import LLMExecutor
@@ -72,12 +73,28 @@ def create_app(
         if not req.messages:
             return {"choices": []}
         content = req.messages[-1].content
+        if req.stream:
+            async def event_stream():
+                reply = await apply_plugins(content)
+                for char in reply:
+                    yield json.dumps({"choices": [{"delta": {"content": char}}]}) + "\n"
+
+            return StreamingResponse(event_stream(), media_type="text/event-stream")
+
         reply = await apply_plugins(content)
         return {"choices": [{"message": {"role": "assistant", "content": reply}}]}
 
     @app.post("/v1/completions")
     async def completions(req: CompletionRequest):
         """Return a completion for the given prompt using the mock backend."""
+        if req.stream:
+            async def event_stream():
+                reply = await apply_plugins(req.prompt)
+                for char in reply:
+                    yield json.dumps({"choices": [{"delta": {"content": char}}]}) + "\n"
+
+            return StreamingResponse(event_stream(), media_type="text/event-stream")
+
         reply = await apply_plugins(req.prompt)
         return {"choices": [{"text": reply}]}
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pytest
 import httpx
 from fastapi.testclient import TestClient
@@ -52,6 +53,38 @@ async def test_plugins(monkeypatch):
         )
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["message"]["content"] == "!!OLLEH!!"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_stream(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app()
+    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hello"}], "stream": True},
+        )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    lines = [l for l in resp.text.splitlines() if l.strip()]
+    reply = "".join(json.loads(l)["choices"][0]["delta"]["content"] for l in lines)
+    assert reply == "olleh"
+
+
+@pytest.mark.asyncio
+async def test_completion_stream(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app()
+    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/completions",
+            json={"prompt": "abc", "stream": True},
+        )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    lines = [l for l in resp.text.splitlines() if l.strip()]
+    reply = "".join(json.loads(l)["choices"][0]["delta"]["content"] for l in lines)
+    assert reply == "cba"
 
 
 def test_root_endpoint():


### PR DESCRIPTION
## Summary
- support streaming in chat/completions API
- test streaming behaviour on both endpoints

## Testing
- `./scripts/setup.sh -d -t` *(installs deps and runs tests)*
- `.venv/bin/pip install pytest-asyncio`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad0a692cc8332a16a3e9eac52b562