### PR TITLE
Add API key auth and basic rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Then navigate to [http://localhost:11434/app](http://localhost:11434/app).
 Double‑click a chat bubble to copy its contents and use the dark‑mode toggle in
 the header to switch themes.
 
+### API Authentication
+
+Set `MOOGLA_API_KEY` to enable simple header based authentication. Requests must
+include an `X-API-Key` header matching the configured value. Optionally set
+`MOOGLA_RATE_LIMIT` to limit the number of requests per minute from a single IP.
+These values can also be passed to `create_app` or `moogla serve`.
+
 ## Running with Docker
 
 Build the image and start the server:

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -6,12 +6,27 @@ from .server import start_server
 
 app = typer.Typer(help="Moogla command line interface")
 
+
 @app.command()
 def serve(
     host: str = "0.0.0.0",
     port: int = 11434,
     plugin: List[str] = typer.Option(
-        None, '--plugin', '-p', help='Plugin module to load', show_default=False
+        None, "--plugin", "-p", help="Plugin module to load", show_default=False
+    ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        help="API key required for server access",
+        envvar="MOOGLA_API_KEY",
+        show_default=False,
+    ),
+    rate_limit: int = typer.Option(
+        None,
+        "--rate-limit",
+        help="Requests per minute allowed per IP",
+        envvar="MOOGLA_RATE_LIMIT",
+        show_default=False,
     ),
 ):
     """Start the Moogla HTTP server.
@@ -22,7 +37,13 @@ def serve(
     port: TCP port to listen on.
     plugin: Optional plugin modules to initialize.
     """
-    start_server(host=host, port=port, plugin_names=plugin)
+    start_server(
+        host=host,
+        port=port,
+        plugin_names=plugin,
+        server_api_key=api_key,
+        rate_limit=rate_limit,
+    )
 
 
 @app.command()
@@ -34,6 +55,7 @@ def pull(model: str):
     model: Identifier of the model to fetch.
     """
     typer.echo(f"Pulling {model} ... done.")
+
 
 if __name__ == "__main__":
     app()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,38 @@
+import httpx
+import pytest
+from moogla import server
+from moogla.server import create_app
+
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_access(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(server_api_key="secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/completions",
+            json={"prompt": "abc"},
+            headers={"X-API-Key": "secret"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(server_api_key="secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 401

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,23 +7,25 @@ import types
 
 runner = CliRunner()
 
+
 def test_help():
-    result = runner.invoke(app, ['--help'])
+    result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert 'serve' in result.output
-    assert 'pull' in result.output
+    assert "serve" in result.output
+    assert "pull" in result.output
+
 
 def test_pull():
-    result = runner.invoke(app, ['pull', 'test-model'])
+    result = runner.invoke(app, ["pull", "test-model"])
     assert result.exit_code == 0
-    assert 'Pulling test-model ... done.' in result.output
+    assert "Pulling test-model ... done." in result.output
 
 
 def test_serve_with_plugin(monkeypatch):
     captured = {}
 
-    def fake_run(app, host='0.0.0.0', port=11434):
-        captured['app'] = app
+    def fake_run(app, host="0.0.0.0", port=11434):
+        captured["app"] = app
 
     class DummyClient:
         def __init__(self, content: str = "HI") -> None:
@@ -32,22 +34,28 @@ def test_serve_with_plugin(monkeypatch):
 
         def create(self, model, messages, max_tokens):
             return types.SimpleNamespace(
-                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=self.content))]
+                choices=[
+                    types.SimpleNamespace(
+                        message=types.SimpleNamespace(content=self.content)
+                    )
+                ]
             )
 
-    monkeypatch.setattr(server, 'uvicorn', types.SimpleNamespace(run=fake_run))
-    monkeypatch.setattr(openai, 'OpenAI', lambda api_key=None, base_url=None: DummyClient("CBA"))
+    monkeypatch.setattr(server, "uvicorn", types.SimpleNamespace(run=fake_run))
+    monkeypatch.setattr(
+        openai, "OpenAI", lambda api_key=None, base_url=None: DummyClient("CBA")
+    )
 
     class DummyExecutor:
         async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
             return prompt[::-1]
 
-    monkeypatch.setattr(server, 'LLMExecutor', lambda *a, **kw: DummyExecutor())
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
 
-    result = runner.invoke(app, ['serve', '--plugin', 'tests.dummy_plugin'])
+    result = runner.invoke(app, ["serve", "--plugin", "tests.dummy_plugin"])
     assert result.exit_code == 0
 
-    client = TestClient(captured['app'])
-    resp = client.post('/v1/completions', json={'prompt': 'abc'})
+    client = TestClient(captured["app"])
+    resp = client.post("/v1/completions", json={"prompt": "abc"})
     assert resp.status_code == 200
-    assert resp.json()['choices'][0]['text'] == '!!CBA!!'
+    assert resp.json()["choices"][0]["text"] == "!!CBA!!"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -21,7 +21,9 @@ class DummyExecutor:
 async def test_chat_completion(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app()
-    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.post(
             "/v1/chat/completions",
             json={"messages": [{"role": "user", "content": "hello"}]},
@@ -35,7 +37,9 @@ async def test_chat_completion(monkeypatch):
 async def test_completion_endpoint(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app()
-    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.post("/v1/completions", json={"prompt": "abc"})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["text"] == "cba"
@@ -45,7 +49,9 @@ async def test_completion_endpoint(monkeypatch):
 async def test_plugins(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app(["tests.dummy_plugin"])
-    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.post(
             "/v1/chat/completions",
             json={"messages": [{"role": "user", "content": "hello"}]},


### PR DESCRIPTION
## Summary
- add optional API authentication and rate limiting middleware
- expose new CLI flags to configure them
- document configuration in README
- update tests for authenticated/unauthenticated access

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad0a944a883328edec40c6c7fd3f1