### PR TITLE
Add missing imports and cleanup

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -1,7 +1,11 @@
 from typing import List, Optional
 
 import os
+import json
+import logging
 
+from fastapi import FastAPI, Header, Depends, HTTPException
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from pathlib import Path
@@ -10,7 +14,7 @@ from pydantic import BaseModel
 import uvicorn
 
 
-from .plugins import Plugin, load_plugins
+from .plugins import load_plugins
 from .executor import LLMExecutor
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add json & logging imports
- import FastAPI components and responses
- drop unused Plugin import

## Testing
- `pip install -e '.[dev]'`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad5258bb0833299fa0665a04aa07c