### PR TITLE
Integrate fastapi-limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ the header to switch themes.
 Set `MOOGLA_API_KEY` to enable simple header based authentication. Requests must
 include an `X-API-Key` header matching the configured value. Optionally set
 `MOOGLA_RATE_LIMIT` to limit the number of requests per minute from a single IP.
-These values can also be passed to `create_app` or `moogla serve`.
+When rate limiting is enabled, `MOOGLA_REDIS_URL` controls the Redis connection
+used for tracking request counts (default `redis://localhost:6379`). These values
+can also be passed to `create_app` or `moogla serve`.
 
 ## Running with Docker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "uvicorn>=0.28",
     "openai>=1.30",
     "httpx>=0.27,<0.28",
+    "fastapi-limiter>=0.1",
+    "redis>=4.5",
 ]
 
 [project.scripts]
@@ -25,7 +27,9 @@ moogla = "moogla.cli:app"
 dev = [
     "pytest",
     "pre-commit",
-    "httpx>=0.27,<0.28"
+    "httpx>=0.27,<0.28",
+    "fakeredis>=2.0",
+    "pytest-asyncio"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -33,6 +33,13 @@ def serve(
         envvar="MOOGLA_RATE_LIMIT",
         show_default=False,
     ),
+    redis_url: str = typer.Option(
+        None,
+        "--redis-url",
+        help="Redis connection string for rate limiting",
+        envvar="MOOGLA_REDIS_URL",
+        show_default=False,
+    ),
 ):
     """Start the Moogla HTTP server.
 
@@ -48,6 +55,7 @@ def serve(
         plugin_names=plugin,
         server_api_key=api_key,
         rate_limit=rate_limit,
+        redis_url=redis_url,
     )
 
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,44 @@
+import os
+import pytest
+import httpx
+from fastapi import HTTPException
+from starlette.requests import Request
+from starlette.responses import Response
+
+from moogla import server
+from moogla.server import create_app
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+@pytest.mark.asyncio
+async def test_rate_limit(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    class MemoryLimiter:
+        def __init__(self, times):
+            self.times = times
+            self.hits = {}
+
+        async def __call__(self, request: Request, response: Response):
+            ip = request.client.host
+            count = self.hits.get(ip, 0) + 1
+            self.hits[ip] = count
+            if count > self.times:
+                raise HTTPException(status_code=429, detail="Too Many Requests")
+
+    monkeypatch.setattr(server, "RateLimiter", lambda times=1, seconds=60: MemoryLimiter(times))
+    monkeypatch.setattr(server, "FastAPILimiter", type("Dummy", (), {"init": lambda *a, **k: None, "close": lambda *a, **k: None}))
+    app = create_app(rate_limit=1, redis_url="redis://test")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.post("/v1/completions", json={"prompt": "abc"})
+        resp = await client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- support Redis-backed rate limiting using fastapi-limiter
- document new environment variable in README
- expose `--redis-url` option in CLI
- add dev dependencies and a test for rate limiting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adab1cc608332b407167fa4ad4adb