### PR TITLE
Add persistent plugin configuration

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -8,8 +8,36 @@ import httpx
 import typer
 
 from .server import start_server
+from . import plugins_config
 
 app = typer.Typer(help="Moogla command line interface")
+plugin_app = typer.Typer(help="Manage plugins")
+app.add_typer(plugin_app, name="plugin")
+
+
+@plugin_app.command("add")
+def plugin_add(name: str) -> None:
+    """Add a plugin to the persistent store."""
+    plugins_config.add_plugin(name)
+    typer.echo(f"Added {name}")
+
+
+@plugin_app.command("remove")
+def plugin_remove(name: str) -> None:
+    """Remove a plugin from the store."""
+    plugins_config.remove_plugin(name)
+    typer.echo(f"Removed {name}")
+
+
+@plugin_app.command("list")
+def plugin_list() -> None:
+    """List configured plugins."""
+    names = plugins_config.get_plugins()
+    if not names:
+        typer.echo("No plugins configured")
+    else:
+        for n in names:
+            typer.echo(n)
 
 
 @app.command()

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -4,6 +4,8 @@ from types import ModuleType
 from typing import Callable, List, Optional
 import inspect
 
+from . import plugins_config
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,7 +33,9 @@ class Plugin:
 
 
 def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
-    """Import and initialize plugins from module names."""
+    """Import and initialize plugins from module names or configured store."""
+    if not names:
+        names = plugins_config.get_plugins()
     plugins: List[Plugin] = []
     for name in names or []:
         try:

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -1,0 +1,55 @@
+import os
+import json
+import sqlite3
+from pathlib import Path
+from typing import List
+
+
+def _get_path() -> Path:
+    env = os.getenv("MOOGLA_PLUGIN_DB")
+    return Path(env) if env else Path.home() / ".cache" / "moogla" / "plugins.db"
+
+
+def _ensure_db(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    return conn
+
+
+def _set_plugins(names: List[str], path: Path) -> None:
+    conn = _ensure_db(path)
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO config(key, value) VALUES('plugins', ?)",
+            (json.dumps(names),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_plugins() -> List[str]:
+    path = _get_path()
+    conn = _ensure_db(path)
+    try:
+        row = conn.execute("SELECT value FROM config WHERE key='plugins'").fetchone()
+        return json.loads(row[0]) if row else []
+    finally:
+        conn.close()
+
+
+def add_plugin(name: str) -> None:
+    names = get_plugins()
+    if name not in names:
+        names.append(name)
+        _set_plugins(names, _get_path())
+
+
+def remove_plugin(name: str) -> None:
+    names = get_plugins()
+    if name in names:
+        names.remove(name)
+        _set_plugins(names, _get_path())

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -1,0 +1,44 @@
+from typer.testing import CliRunner
+import httpx
+from fastapi.testclient import TestClient
+
+from moogla.cli import app
+from moogla import server, plugins_config
+
+runner = CliRunner()
+
+
+def test_cli_plugin_management(tmp_path, monkeypatch):
+    db = tmp_path / "plugins.db"
+    monkeypatch.setenv("MOOGLA_PLUGIN_DB", str(db))
+
+    result = runner.invoke(app, ["plugin", "add", "tests.dummy_plugin"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(app, ["plugin", "list"])
+    assert result.exit_code == 0
+    assert "tests.dummy_plugin" in result.output
+
+    result = runner.invoke(app, ["plugin", "remove", "tests.dummy_plugin"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(app, ["plugin", "list"])
+    assert "tests.dummy_plugin" not in result.output
+
+
+class DummyExecutor:
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+def test_persisted_plugins_loaded(tmp_path, monkeypatch):
+    db = tmp_path / "plugins.db"
+    monkeypatch.setenv("MOOGLA_PLUGIN_DB", str(db))
+    plugins_config.add_plugin("tests.dummy_plugin")
+
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app_instance = server.create_app()
+    client = TestClient(app_instance)
+    resp = client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "!!CBA!!"


### PR DESCRIPTION
## Summary
- store enabled plugins in an SQLite DB using new `plugins_config` module
- allow `load_plugins` to read plugins from the store
- add `moogla plugin` CLI for add/remove/list
- test plugin persistence and CLI commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adab426c88332a0ee882d34839f99