### PR TITLE
Add CI linting and mypy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
           pip install pytest-asyncio
+      - name: Lint with ruff
+        run: ruff src tests
+      - name: Type check with mypy
+        run: mypy src tests
       - name: Run tests
         run: pytest
 

--- a/README.md
+++ b/README.md
@@ -120,4 +120,6 @@ docker-compose up
 - Keep functions small and composable.
 - Write unit tests for new behavior in `tests/`.
 - Use type hints and docstrings.
+- Pull requests are checked by GitHub Actions.
+- Ensure `pytest`, `ruff` and `mypy` pass before pushing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ moogla = "moogla.cli:app"
 dev = [
     "pytest",
     "pre-commit",
-    "httpx>=0.27,<0.28"
+    "httpx>=0.27,<0.28",
+    "ruff",
+    "mypy"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 import os
 from pathlib import Path
 from urllib.parse import urlparse
@@ -82,24 +82,24 @@ def pull(
         with httpx.stream("GET", url) as resp:
             resp.raise_for_status()
             total = int(resp.headers.get("content-length", 0))
-            with open(dest, "wb") as f, typer.progressbar(
-                length=total or None, label="Downloading"
-            ) as bar:
-                for chunk in resp.iter_bytes():
-                    f.write(chunk)
-                    if total:
-                        bar.update(len(chunk))
+            with open(dest, "wb") as f:
+                bar: Any
+                with typer.progressbar(length=total or None, label="Downloading") as bar:
+                    for chunk in resp.iter_bytes():
+                        f.write(chunk)
+                        if total:
+                            bar.update(len(chunk))
     elif Path(model).is_file():
         size = os.path.getsize(model)
-        with open(model, "rb") as src, open(dest, "wb") as dst, typer.progressbar(
-            length=size, label="Downloading"
-        ) as bar:
-            while True:
-                data = src.read(8192)
-                if not data:
-                    break
-                dst.write(data)
-                bar.update(len(data))
+        with open(model, "rb") as src, open(dest, "wb") as dst:
+            progress: Any
+            with typer.progressbar(length=size, label="Downloading") as progress:
+                while True:
+                    data = src.read(8192)
+                    if not data:
+                        break
+                    dst.write(data)
+                    progress.update(len(data))
     else:
         typer.echo(f"Unknown model source: {model}")
         raise typer.Exit(code=1)

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -1,6 +1,7 @@
-from __future__ import annotations
 
 """Utilities for executing prompts against LLM providers."""
+
+from __future__ import annotations
 
 from typing import Optional
 import os
@@ -24,7 +25,9 @@ class LLMExecutor:
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,
         )
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        assert content is not None
+        return content
 
     async def acomplete(self, prompt: str, *, max_tokens: int = 16) -> str:
         """Asynchronously return a completion for the given prompt."""
@@ -33,4 +36,6 @@ class LLMExecutor:
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,
         )
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        assert content is not None
+        return content

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional, cast
 
 import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException
@@ -28,9 +28,12 @@ def create_app(
     """Build the FastAPI application."""
     plugins = load_plugins(plugin_names)
 
-    model = model or os.getenv("MOOGLA_MODEL", "gpt-3.5-turbo")
-    api_key = api_key or os.getenv("OPENAI_API_KEY")
-    api_base = api_base or os.getenv("OPENAI_API_BASE")
+    if model is None:
+        model = os.getenv("MOOGLA_MODEL") or "gpt-3.5-turbo"
+    if api_key is None:
+        api_key = os.getenv("OPENAI_API_KEY") or ""
+    if api_base is None:
+        api_base = os.getenv("OPENAI_API_BASE")
     server_api_key = server_api_key or os.getenv("MOOGLA_API_KEY")
     if rate_limit is None:
         env_limit = os.getenv("MOOGLA_RATE_LIMIT")
@@ -81,7 +84,7 @@ def create_app(
                             return
                 await self.app(scope, receive, send)
 
-        app.add_middleware(RateLimitMiddleware, limit=rate_limit)
+        app.add_middleware(cast(Any, RateLimitMiddleware), limit=rate_limit)
 
     static_dir = Path(__file__).resolve().parent / "web"
     if static_dir.exists():

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -72,8 +72,10 @@ async def test_chat_completion_stream(monkeypatch):
         )
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/event-stream")
-    lines = [l for l in resp.text.splitlines() if l.strip()]
-    reply = "".join(json.loads(l)["choices"][0]["delta"]["content"] for l in lines)
+    lines = [line for line in resp.text.splitlines() if line.strip()]
+    reply = "".join(
+        json.loads(line)["choices"][0]["delta"]["content"] for line in lines
+    )
     assert reply == "olleh"
 
 
@@ -88,8 +90,10 @@ async def test_completion_stream(monkeypatch):
         )
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/event-stream")
-    lines = [l for l in resp.text.splitlines() if l.strip()]
-    reply = "".join(json.loads(l)["choices"][0]["delta"]["content"] for l in lines)
+    lines = [line for line in resp.text.splitlines() if line.strip()]
+    reply = "".join(
+        json.loads(line)["choices"][0]["delta"]["content"] for line in lines
+    )
     assert reply == "cba"
 
 


### PR DESCRIPTION
## Summary
- run ruff and mypy in CI
- keep CI install step simple
- enforce linting and static typing in README guidelines
- fix style issues in tests and code

## Testing
- `pytest -q`
- `ruff check src tests`
- `mypy src tests`


------
https://chatgpt.com/codex/tasks/task_e_685adab5fd748332931ea8bde276f958