### PR TITLE
Add db-url option to serve command

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -68,6 +68,13 @@ def serve(
         envvar="MOOGLA_REDIS_URL",
         show_default=False,
     ),
+    db_url: str = typer.Option(
+        None,
+        "--db-url",
+        help="Database connection string",
+        envvar="MOOGLA_DB_URL",
+        show_default=False,
+    ),
 ):
     """Start the Moogla HTTP server.
 
@@ -76,6 +83,7 @@ def serve(
     host: IP or hostname to bind.
     port: TCP port to listen on.
     plugin: Optional plugin modules to initialize.
+    db_url: Optional database connection string.
     """
     start_server(
         host=host,
@@ -84,6 +92,7 @@ def serve(
         server_api_key=api_key,
         rate_limit=rate_limit,
         redis_url=redis_url,
+        db_url=db_url,
     )
 
 

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -27,6 +27,7 @@ def create_app(
     server_api_key: Optional[str] = None,
     rate_limit: Optional[int] = None,
     redis_url: Optional[str] = None,
+    db_url: Optional[str] = None,
 ) -> FastAPI:
     """Build the FastAPI application."""
     plugins = load_plugins(plugin_names)
@@ -67,6 +68,7 @@ def create_app(
         await FastAPILimiter.close()
 
     app = FastAPI(title="Moogla API", dependencies=dependencies, lifespan=lifespan)
+    app.state.db_url = db_url
 
     static_dir = Path(__file__).resolve().parent / "web"
     if static_dir.exists():
@@ -156,6 +158,7 @@ def start_server(
     server_api_key: Optional[str] = None,
     rate_limit: Optional[int] = None,
     redis_url: Optional[str] = None,
+    db_url: Optional[str] = None,
 ) -> None:
     """Run the HTTP server."""
     app = create_app(
@@ -166,5 +169,6 @@ def start_server(
         server_api_key=server_api_key,
         rate_limit=rate_limit,
         redis_url=redis_url,
+        db_url=db_url,
     )
     uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- extend `serve` command with `--db-url` option
- propagate `db_url` through `start_server` into `create_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adeed61508332be78be885a3a6d74