### PR TITLE
Add User model with unique username

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "httpx>=0.27,<0.28",
     "fastapi-limiter>=0.1",
     "redis>=4.5",
+    "sqlmodel>=0.0.24",
 ]
 
 [project.scripts]

--- a/src/moogla/auth.py
+++ b/src/moogla/auth.py
@@ -1,0 +1,9 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+class User(SQLModel, table=True):
+    """Simple user model with a unique username."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    username: str = Field(index=True, sa_column_kwargs={"unique": True})
+    hashed_password: str


### PR DESCRIPTION
## Summary
- add SQLModel `User` table in `auth.py`
- include `sqlmodel` dependency

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adeef5a908332a8f89cb8d503de04