### PR TITLE
Add secret key option to auth init

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ When rate limiting is enabled, `MOOGLA_REDIS_URL` controls the Redis connection
 used for tracking request counts (default `redis://localhost:6379`). These values
 can also be passed to `create_app` or `moogla serve`.
 
+The authentication subsystem relies on a secret key for signing tokens. Set
+`MOOGLA_SECRET_KEY` to override the default value of `"secret"`.
+
 ## Running with Docker
 
 Build the image and start the server:

--- a/src/moogla/auth.py
+++ b/src/moogla/auth.py
@@ -1,0 +1,35 @@
+# Authentication utilities for Moogla
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+_db_url: Optional[str] = None
+_secret_key: Optional[str] = None
+
+
+def init(db_url: str, secret_key: Optional[str] = None) -> None:
+    """Initialize authentication backend.
+
+    Parameters
+    ----------
+    db_url:
+        Path to the user database, e.g. ``sqlite:///users.db``.
+    secret_key:
+        Key used to sign session tokens. Defaults to the ``MOOGLA_SECRET_KEY``
+        environment variable or ``"secret"`` if unset.
+    """
+    global _db_url, _secret_key
+    _db_url = db_url
+    _secret_key = secret_key or os.getenv("MOOGLA_SECRET_KEY", "secret")
+
+
+def get_db_url() -> Optional[str]:
+    """Return the configured database URL."""
+    return _db_url
+
+
+def get_secret_key() -> Optional[str]:
+    """Return the secret key used for signing."""
+    return _secret_key


### PR DESCRIPTION
## Summary
- introduce `moogla.auth` module
- allow passing a secret key to `auth.init`
- forward `secret_key` option from `create_app`/`start_server`
- document `MOOGLA_SECRET_KEY` in README

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adef0d6d483329e7bf6a8fcd57633