### PR TITLE
Fix plugin error tests and update httpx usage

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -27,8 +27,11 @@ def create_app(
     server_api_key: Optional[str] = None,
     rate_limit: Optional[int] = None,
     redis_url: Optional[str] = None,
+    db_url: Optional[str] = None,
 ) -> FastAPI:
     """Build the FastAPI application."""
+    if db_url:
+        os.environ["MOOGLA_PLUGIN_DB"] = db_url.replace("sqlite:///", "")
     plugins = load_plugins(plugin_names)
 
     model = model or os.getenv("MOOGLA_MODEL", "gpt-3.5-turbo")
@@ -156,6 +159,7 @@ def start_server(
     server_api_key: Optional[str] = None,
     rate_limit: Optional[int] = None,
     redis_url: Optional[str] = None,
+    db_url: Optional[str] = None,
 ) -> None:
     """Run the HTTP server."""
     app = create_app(
@@ -166,5 +170,6 @@ def start_server(
         server_api_key=server_api_key,
         rate_limit=rate_limit,
         redis_url=redis_url,
+        db_url=db_url,
     )
     uvicorn.run(app, host=host, port=port)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -65,7 +65,9 @@ async def test_plugins(monkeypatch):
 async def test_chat_completion_stream(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app()
-    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.post(
             "/v1/chat/completions",
             json={"messages": [{"role": "user", "content": "hello"}], "stream": True},
@@ -81,7 +83,9 @@ async def test_chat_completion_stream(monkeypatch):
 async def test_completion_stream(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app()
-    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.post(
             "/v1/completions",
             json={"prompt": "abc", "stream": True},

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -21,7 +21,7 @@ class DummyExecutor:
         return prompt[::-1]
 
 
-def test_preprocess_exception_results_in_500(monkeypatch):
+def test_preprocess_exception_results_in_500(tmp_path, monkeypatch):
     mod = types.ModuleType('error_pre_plugin')
 
     def preprocess(text: str) -> str:
@@ -30,7 +30,7 @@ def test_preprocess_exception_results_in_500(monkeypatch):
     mod.preprocess = preprocess
     sys.modules['error_pre_plugin'] = mod
     monkeypatch.setattr("moogla.server.LLMExecutor", lambda *a, **kw: DummyExecutor())
-    app = create_app(['error_pre_plugin'])
+    app = create_app(['error_pre_plugin'], db_url=f"sqlite:///{tmp_path}/db.db")
     client = TestClient(app, raise_server_exceptions=False)
     resp = client.post('/v1/completions', json={'prompt': 'abc'})
     assert resp.status_code == 500
@@ -38,7 +38,7 @@ def test_preprocess_exception_results_in_500(monkeypatch):
     sys.modules.pop('error_pre_plugin', None)
 
 
-def test_postprocess_exception_results_in_500(monkeypatch):
+def test_postprocess_exception_results_in_500(tmp_path, monkeypatch):
     mod = types.ModuleType('error_post_plugin')
 
     def postprocess(text: str) -> str:
@@ -47,7 +47,7 @@ def test_postprocess_exception_results_in_500(monkeypatch):
     mod.postprocess = postprocess
     sys.modules['error_post_plugin'] = mod
     monkeypatch.setattr("moogla.server.LLMExecutor", lambda *a, **kw: DummyExecutor())
-    app = create_app(['error_post_plugin'])
+    app = create_app(['error_post_plugin'], db_url=f"sqlite:///{tmp_path}/db.db")
     client = TestClient(app, raise_server_exceptions=False)
     resp = client.post('/v1/completions', json={'prompt': 'abc'})
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- test plugin errors with explicit sqlite db path
- adjust streaming endpoint tests for newer HTTPX
- allow passing plugin database URL to `create_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adef210b48332aac464386f1c27e2