### PR TITLE
Extend plugin API with async hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ curl -X POST http://localhost:11434/v1/chat/completions \
   -d '{"messages": [{"role": "user", "content": "hello"}]}'
 ```
 
+### Plugin API
+
+Plugins are regular Python modules that expose optional `preprocess` and
+`postprocess` hooks. Asynchronous variants named `preprocess_async` and
+`postprocess_async` are also supported. Hooks receive the current text and
+return the modified value.
+
+A plugin can specify an integer `order` attribute to control execution order
+when multiple plugins are loaded. Lower numbers run first.
+
 ## Development Setup
 
 The project uses [Typer](https://typer.tiangolo.com/) for the CLI and

--- a/tests/async_plugin.py
+++ b/tests/async_plugin.py
@@ -1,0 +1,9 @@
+import asyncio
+
+async def preprocess_async(text: str) -> str:
+    await asyncio.sleep(0)
+    return text.upper()
+
+async def postprocess_async(text: str) -> str:
+    await asyncio.sleep(0)
+    return f"<{text}>"

--- a/tests/order_plugin_a.py
+++ b/tests/order_plugin_a.py
@@ -1,0 +1,4 @@
+order = 10
+
+def preprocess(text: str) -> str:
+    return text + 'a'

--- a/tests/order_plugin_b.py
+++ b/tests/order_plugin_b.py
@@ -1,0 +1,4 @@
+order = 5
+
+def preprocess(text: str) -> str:
+    return text + 'b'

--- a/tests/test_async_plugin.py
+++ b/tests/test_async_plugin.py
@@ -1,0 +1,36 @@
+import os
+import httpx
+import pytest
+
+from moogla.server import create_app
+from moogla import server
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+@pytest.mark.asyncio
+async def test_async_plugin(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(["tests.async_plugin"])
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/v1/completions", json={"prompt": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "<IH>"
+
+
+@pytest.mark.asyncio
+async def test_plugin_order(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(["tests.order_plugin_a", "tests.order_plugin_b"])
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/v1/completions", json={"prompt": "x"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "abx"


### PR DESCRIPTION
## Summary
- enhance `Plugin` to support explicit async hooks and ordering
- document extended plugin API
- add async plugin tests and ordering tests

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aee65a10883329d5406dfcf61b98f