### PR TITLE
Add local model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Pull a model and start the server with a custom plugin:
 
 ```bash
 moogla pull codellama:13b
-moogla serve --plugin tests.dummy_plugin
+moogla serve --model path/to/codellama-13b.gguf --plugin tests.dummy_plugin
+```
+
+To use a Hugging Face model ID instead of a file path:
+
+```bash
+moogla serve --model mistralai/Mistral-7B-Instruct-v0.2
 ```
 
 You can then query the chat completion endpoint:

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -47,6 +47,20 @@ def serve(
     plugin: List[str] = typer.Option(
         None, "--plugin", "-p", help="Plugin module to load", show_default=False
     ),
+    model: str = typer.Option(
+        None,
+        "--model",
+        help="Model path or identifier",
+        envvar="MOOGLA_MODEL",
+        show_default=False,
+    ),
+    api_base: str = typer.Option(
+        None,
+        "--api-base",
+        help="Base URL for remote API",
+        envvar="OPENAI_API_BASE",
+        show_default=False,
+    ),
     api_key: str = typer.Option(
         None,
         "--api-key",
@@ -89,6 +103,8 @@ def serve(
         host=host,
         port=port,
         plugin_names=plugin,
+        model=model,
+        api_base=api_base,
         server_api_key=api_key,
         rate_limit=rate_limit,
         redis_url=redis_url,

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Optional
 import os
+from pathlib import Path
+import asyncio
 
 import openai
 
@@ -13,24 +15,58 @@ class LLMExecutor:
 
     def __init__(self, model: str, api_key: Optional[str] = None, api_base: Optional[str] = None) -> None:
         self.model = model
+        self.client = None
+        self.async_client = None
+        self.generator = None
+        self.llama = None
+
         key = api_key or os.getenv("OPENAI_API_KEY")
-        self.client = openai.OpenAI(api_key=key, base_url=api_base)
-        self.async_client = openai.AsyncOpenAI(api_key=key, base_url=api_base)
+
+        model_path = Path(model)
+        if model_path.exists() or "/" in model:
+            if model_path.suffix in {".gguf", ".ggml", ".bin"}:
+                try:
+                    from llama_cpp import Llama
+                except Exception as exc:  # pragma: no cover - optional dep
+                    raise RuntimeError("llama-cpp-python required for GGUF models") from exc
+
+                self.llama = Llama(model_path=str(model_path))
+            else:
+                try:
+                    from transformers import pipeline
+                except Exception as exc:  # pragma: no cover - optional dep
+                    raise RuntimeError("transformers required for HuggingFace models") from exc
+
+                self.generator = pipeline("text-generation", model=str(model_path))
+        else:
+            self.client = openai.OpenAI(api_key=key, base_url=api_base)
+            self.async_client = openai.AsyncOpenAI(api_key=key, base_url=api_base)
 
     def complete(self, prompt: str, *, max_tokens: int = 16) -> str:
         """Return a completion for the given prompt."""
-        response = self.client.chat.completions.create(
-            model=self.model,
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-        )
-        return response.choices[0].message.content
+        if self.client:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_tokens,
+            )
+            return response.choices[0].message.content
+        if self.generator:
+            result = self.generator(prompt, max_new_tokens=max_tokens)
+            return result[0]["generated_text"]
+        if self.llama:
+            result = self.llama(prompt, max_tokens=max_tokens)
+            return result["choices"][0]["text"]
+        raise RuntimeError("No LLM backend configured")
 
     async def acomplete(self, prompt: str, *, max_tokens: int = 16) -> str:
         """Asynchronously return a completion for the given prompt."""
-        response = await self.async_client.chat.completions.create(
-            model=self.model,
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-        )
-        return response.choices[0].message.content
+        if self.async_client:
+            response = await self.async_client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_tokens,
+            )
+            return response.choices[0].message.content
+        # fall back to thread pool for sync models
+        return await asyncio.to_thread(self.complete, prompt, max_tokens=max_tokens)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -23,3 +23,21 @@ def test_complete(monkeypatch):
     executor = LLMExecutor(model="gpt-3.5-turbo")
     result = executor.complete("hello")
     assert result == "hi"
+
+
+def test_hf_backend(monkeypatch):
+    import sys
+
+    class DummyPipeline:
+        def __call__(self, text, max_new_tokens=16):
+            return [{"generated_text": text[::-1]}]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        types.SimpleNamespace(pipeline=lambda *a, **k: DummyPipeline()),
+    )
+
+    executor = LLMExecutor(model="some/model")
+    result = executor.complete("abc")
+    assert result == "cba"


### PR DESCRIPTION
## Summary
- allow `LLMExecutor` to load huggingface or llama.cpp models
- support `--model` and `--api-base` options in CLI
- document local model usage in README
- test local HF backend with a dummy pipeline

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aee663ebc8332b1b732e27be2a8ca