### PR TITLE
Add MkDocs documentation and workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs
+      - name: Build docs
+        run: mkdocs build --strict
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ environment variables:
 docker-compose up
 ```
 
+## Documentation
+
+Full documentation is available on GitHub Pages and can be built locally with:
+
+```bash
+mkdocs serve
+```
+
+
 
 ## Contributing Guidelines
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,15 @@
+# Authentication
+
+Set `MOOGLA_API_KEY` to require a header named `X-API-Key` on requests.
+
+```bash
+export MOOGLA_API_KEY=secret
+moogla serve
+```
+
+The API also provides `/register` and `/login` endpoints for JWT based
+authentication. After registration, send the returned token in an
+`Authorization: Bearer <token>` header.
+
+Rate limiting can be enabled with `MOOGLA_RATE_LIMIT` and a Redis
+connection via `MOOGLA_REDIS_URL`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Welcome to Moogla
+
+Moogla is a local-first LLM runtime and orchestration framework. This
+site contains user and developer documentation.
+
+## Sections
+
+- [Setup](setup.md)
+- [Plugin Development](plugins.md)
+- [Authentication](authentication.md)
+- [Web UI](web_ui.md)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,31 @@
+# Plugin Development
+
+Moogla can load custom plugins to modify prompts and responses. A plugin
+is a Python module that exposes optional `preprocess` and `postprocess`
+functions.
+
+Example plugin:
+
+```python
+# my_plugin.py
+
+def preprocess(text: str) -> str:
+    return text.upper()
+
+def postprocess(text: str) -> str:
+    return f"!!{text}!!"
+```
+
+Plugins can be loaded at startup using `--plugin`:
+
+```bash
+moogla serve --plugin my_plugin
+```
+
+You can also persist plugin names using the CLI:
+
+```bash
+moogla plugin add my_plugin
+moogla plugin list
+moogla plugin remove my_plugin
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,20 @@
+# Setup
+
+The project requires Python 3.9 or newer. A helper script is provided to
+create a virtual environment and install dependencies.
+
+```bash
+./scripts/setup.sh
+```
+
+To install development tools run:
+
+```bash
+pip install -e .[dev]
+```
+
+Run the CLI to see available commands:
+
+```bash
+moogla --help
+```

--- a/docs/web_ui.md
+++ b/docs/web_ui.md
@@ -1,0 +1,12 @@
+# Web UI
+
+Moogla ships with a small browser interface located in `src/moogla/web`.
+Start the server and navigate to `/app` to use it:
+
+```bash
+moogla serve
+# then open http://localhost:11434/app
+```
+
+Double click a chat bubble to copy its text. Use the dark‑mode toggle in
+the header to switch themes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: Moogla Documentation
+site_url: https://rehkad.github.io/Moogla
+docs_dir: docs
+theme:
+  name: readthedocs
+nav:
+  - Home: index.md
+  - Setup: setup.md
+  - Plugin Development: plugins.md
+  - Authentication: authentication.md
+  - Web UI: web_ui.md


### PR DESCRIPTION
## Summary
- set up MkDocs site with pages for setup, plugins, auth and the web UI
- mention hosted docs in README
- configure docs.yml workflow to publish docs to GitHub Pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aee66ec088332b7b334d2d075e3d7