### PR TITLE
Add global Settings via pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "sqlmodel>=0.0.24",
     "passlib[bcrypt]>=1.7",
     "python-jose>=3.3",
+    "pydantic-settings>=2.0",
 ]
 
 [project.scripts]

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -9,6 +9,7 @@ import typer
 
 from .server import start_server
 from . import plugins_config
+from .config import Settings
 
 app = typer.Typer(help="Moogla command line interface")
 plugin_app = typer.Typer(help="Manage plugins")
@@ -89,6 +90,20 @@ def serve(
         envvar="MOOGLA_DB_URL",
         show_default=False,
     ),
+    jwt_secret: str = typer.Option(
+        None,
+        "--jwt-secret",
+        help="Secret key for JWT tokens",
+        envvar="MOOGLA_JWT_SECRET",
+        show_default=False,
+    ),
+    plugin_db: str = typer.Option(
+        None,
+        "--plugin-db",
+        help="Path to plugin configuration DB",
+        envvar="MOOGLA_PLUGIN_DB",
+        show_default=False,
+    ),
 ):
     """Start the Moogla HTTP server.
 
@@ -109,10 +124,11 @@ def serve(
         rate_limit=rate_limit,
         redis_url=redis_url,
         db_url=db_url,
+        jwt_secret=jwt_secret,
+        plugin_db=plugin_db,
     )
 
 
-DEFAULT_DIR = Path.home() / ".cache" / "moogla" / "models"
 
 
 @app.command()
@@ -127,7 +143,8 @@ def pull(
     model: Identifier, path or URL of the model to fetch.
     dir: Target directory for the downloaded file.
     """
-    dest_dir = dir or Path(os.getenv("MOOGLA_MODEL_DIR", DEFAULT_DIR))
+    settings = Settings()
+    dest_dir = dir or settings.model_dir
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     parsed = urlparse(model)

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    model: str = Field("gpt-3.5-turbo", env="MOOGLA_MODEL")
+    openai_api_key: Optional[str] = Field(None, env="OPENAI_API_KEY")
+    openai_api_base: Optional[str] = Field(None, env="OPENAI_API_BASE")
+    server_api_key: Optional[str] = Field(None, env="MOOGLA_API_KEY")
+    rate_limit: Optional[int] = Field(None, env="MOOGLA_RATE_LIMIT")
+    redis_url: str = Field("redis://localhost:6379", env="MOOGLA_REDIS_URL")
+    db_url: str = Field("sqlite:///:memory:", env="MOOGLA_DB_URL")
+    plugin_db: Optional[Path] = Field(None, env="MOOGLA_PLUGIN_DB")
+    jwt_secret: str = Field("secret", env="MOOGLA_JWT_SECRET")
+    model_dir: Path = Field(
+        default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
+        env="MOOGLA_MODEL_DIR",
+    )
+
+    model_config = SettingsConfigDict(env_prefix="")

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Utilities for executing prompts against LLM providers."""
 
 from typing import Optional
-import os
 from pathlib import Path
 import asyncio
 
@@ -20,7 +19,7 @@ class LLMExecutor:
         self.generator = None
         self.llama = None
 
-        key = api_key or os.getenv("OPENAI_API_KEY")
+        key = api_key
 
         model_path = Path(model)
         if model_path.exists() or "/" in model:

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -2,12 +2,24 @@ import os
 import json
 import sqlite3
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+
+PLUGIN_DB_PATH: Optional[Path] = None
+
+
+def set_plugin_db(path: Optional[str]) -> None:
+    """Override the location of the plugin database."""
+    global PLUGIN_DB_PATH
+    PLUGIN_DB_PATH = Path(path) if path else None
 
 
 def _get_path() -> Path:
     env = os.getenv("MOOGLA_PLUGIN_DB")
-    return Path(env) if env else Path.home() / ".cache" / "moogla" / "plugins.db"
+    if env:
+        return Path(env)
+    if PLUGIN_DB_PATH is not None:
+        return PLUGIN_DB_PATH
+    return Path.home() / ".cache" / "moogla" / "plugins.db"
 
 
 def _ensure_db(path: Path) -> sqlite3.Connection:


### PR DESCRIPTION
## Summary
- introduce `Settings` configuration class using pydantic-settings
- refactor `create_app` and CLI to use `Settings`
- remove environment variable mutation and centralize config
- expose plugin DB path through plugins_config

## Testing
- `python -m pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af4576a188332abce502ad3c99e3a