### PR TITLE
Add CORS support and enforce JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Include this token in an `Authorization: Bearer <token>` header when calling the
 LLM routes. Authentication support relies on the `SQLModel`, `passlib` and
 `python-jose` packages.
 
+Set `MOOGLA_ENV=production` and provide `MOOGLA_JWT_SECRET` to configure a
+persistent signing key. Cross origin requests can be allowed by specifying
+origins in `MOOGLA_CORS_ORIGINS`.
+
 ## Running with Docker
 
 Build the image and start the server:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,3 +13,9 @@ authentication. After registration, send the returned token in an
 
 Rate limiting can be enabled with `MOOGLA_RATE_LIMIT` and a Redis
 connection via `MOOGLA_REDIS_URL`.
+
+Set `MOOGLA_ENV=production` on deployments and provide a `MOOGLA_JWT_SECRET`
+value to sign tokens. In development mode a default secret is used.
+
+Cross origin requests can be allowed by setting `MOOGLA_CORS_ORIGINS` to a
+comma separated list of origins.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+from moogla.server import create_app
+
+
+def test_secret_required_in_production(monkeypatch):
+    monkeypatch.delenv("MOOGLA_JWT_SECRET", raising=False)
+    monkeypatch.setenv("MOOGLA_ENV", "production")
+    with pytest.raises(RuntimeError):
+        create_app()
+
+
+def test_cors_origins_env(monkeypatch):
+    monkeypatch.setenv("MOOGLA_CORS_ORIGINS", "http://example.com")
+    app = create_app()
+    cors = [m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"]
+    assert cors and cors[0].kwargs["allow_origins"] == ["http://example.com"]


### PR DESCRIPTION
## Summary
- require `MOOGLA_JWT_SECRET` when `MOOGLA_ENV=production`
- expose optional CORS configuration in `create_app`
- document new environment variables
- test JWT secret enforcement and CORS setup

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af458de4c8332a3d5da3b5f00ff1a