### PR TITLE
Enhance streaming support

### DIFF
--- a/tests/test_async_plugin.py
+++ b/tests/test_async_plugin.py
@@ -15,6 +15,11 @@ class DummyExecutor:
     async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
         return prompt[::-1]
 
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
 
 @pytest.mark.asyncio
 async def test_async_plugin(monkeypatch):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,6 +11,11 @@ class DummyExecutor:
     async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
         return prompt[::-1]
 
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
 
 @pytest.mark.asyncio
 async def test_authenticated_access(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,11 @@ def test_serve_with_plugin(monkeypatch):
         async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
             return prompt[::-1]
 
+        async def astream(self, prompt: str, max_tokens: int = 16):
+            text = prompt[::-1]
+            for i in range(0, len(text), 2):
+                yield text[i : i + 2]
+
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
 
     result = runner.invoke(app, ["serve", "--plugin", "tests.dummy_plugin"])

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -17,6 +17,11 @@ class DummyExecutor:
     async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
         return prompt[::-1]
 
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
 
 @pytest.mark.asyncio
 async def test_chat_completion(monkeypatch):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,6 +1,7 @@
 import types
 
 import openai
+import pytest
 
 from moogla.executor import LLMExecutor
 
@@ -41,3 +42,49 @@ def test_hf_backend(monkeypatch):
     executor = LLMExecutor(model="some/model")
     result = executor.complete("abc")
     assert result == "cba"
+
+
+@pytest.mark.asyncio
+async def test_astream(monkeypatch):
+    class DummyStream:
+        def __init__(self, text):
+            self.text = text
+
+        def __iter__(self):
+            for ch in self.text:
+                yield types.SimpleNamespace(choices=[types.SimpleNamespace(delta=types.SimpleNamespace(content=ch))])
+
+    class DummyAsyncStream:
+        def __init__(self, text):
+            self.text = text
+
+        def __aiter__(self):
+            self._iter = iter(self.text)
+            return self
+
+        async def __anext__(self):
+            try:
+                ch = next(self._iter)
+            except StopIteration:
+                raise StopAsyncIteration
+            return types.SimpleNamespace(choices=[types.SimpleNamespace(delta=types.SimpleNamespace(content=ch))])
+
+    class StreamClient(DummyClient):
+        def create(self, model, messages, max_tokens, stream=False):
+            if stream:
+                return DummyStream(self.content)
+            return super().create(model, messages, max_tokens)
+
+    class AsyncStreamClient(StreamClient):
+        async def create(self, model, messages, max_tokens, stream=False):
+            if stream:
+                return DummyAsyncStream(self.content)
+            return super().create(model, messages, max_tokens)
+
+    dummy = StreamClient("hi")
+    adummy = AsyncStreamClient("hi")
+    monkeypatch.setattr(openai, "OpenAI", lambda api_key=None, base_url=None: dummy)
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda api_key=None, base_url=None: adummy)
+    executor = LLMExecutor(model="gpt-3.5-turbo")
+    tokens = [t async for t in executor.astream("hello")]
+    assert tokens == list("hi")

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -30,6 +30,11 @@ class DummyExecutor:
     async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
         return prompt[::-1]
 
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
 
 def test_persisted_plugins_loaded(tmp_path, monkeypatch):
     db = tmp_path / "plugins.db"

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -20,6 +20,11 @@ class DummyExecutor:
     async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
         return prompt[::-1]
 
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
 
 def test_preprocess_exception_results_in_500(tmp_path, monkeypatch):
     mod = types.ModuleType('error_pre_plugin')

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -17,6 +17,11 @@ class DummyExecutor:
     async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
         return prompt[::-1]
 
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
 
 @pytest.mark.asyncio
 async def test_rate_limit(monkeypatch):


### PR DESCRIPTION
## Summary
- improve `LLMExecutor` with token streaming helpers
- update server streaming endpoints to iterate over token streams
- add async streaming tests and update dummy executors

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af45a0e248332a8041f45c003ad0b