### PR TITLE
Document async limitations for llama_cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ return the modified value.
 A plugin can specify an integer `order` attribute to control execution order
 when multiple plugins are loaded. Lower numbers run first.
 
+### Async Limitations
+
+Local models loaded through `llama-cpp-python` do not expose an asynchronous
+interface. When `LLMExecutor.acomplete` is called with such a model, inference
+runs in a background thread via `asyncio.to_thread`. Heavy local workloads can
+therefore limit overall throughput compared to fully async providers.
+
 ## Development Setup
 
 The project uses [Typer](https://typer.tiangolo.com/) for the CLI and

--- a/docs/local_models.md
+++ b/docs/local_models.md
@@ -1,0 +1,5 @@
+# Local Models
+
+Moogla can load GGUF or GGML files through `llama-cpp-python` as well as models from the Hugging Face hub. The `llama-cpp-python` package only exposes synchronous APIs. When the server runs with a local model, calls to `LLMExecutor.acomplete` are executed in a thread using `asyncio.to_thread`.
+
+While this keeps the HTTP API asynchronous, heavy inference will still occupy a worker thread and may reduce overall concurrency. If you rely on high throughput you should consider an async capable backend such as OpenAI's API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ theme:
 nav:
   - Home: index.md
   - Setup: setup.md
+  - Local Models: local_models.md
   - Plugin Development: plugins.md
   - Authentication: authentication.md
   - Web UI: web_ui.md

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -68,5 +68,10 @@ class LLMExecutor:
                 max_tokens=max_tokens,
             )
             return response.choices[0].message.content
-        # fall back to thread pool for sync models
-        return await asyncio.to_thread(self.complete, prompt, max_tokens=max_tokens)
+
+        # ``llama_cpp`` exposes only synchronous APIs so local inference can
+        # block the event loop.  Run any non-async backends in a thread.
+        if self.llama or self.generator or self.client:
+            return await asyncio.to_thread(self.complete, prompt, max_tokens=max_tokens)
+
+        raise RuntimeError("No LLM backend configured")


### PR DESCRIPTION
## Summary
- update `LLMExecutor.acomplete` to use `asyncio.to_thread` for local models
- document async limitations in README
- add docs page on local models
- include new page in mkdocs navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af45b0edc8332bc3cdfe73075463c