### PR TITLE
Add runtime plugin management endpoints

### DIFF
--- a/src/moogla/web/index.html
+++ b/src/moogla/web/index.html
@@ -28,6 +28,9 @@
         <div class="flex items-center space-x-2">
             <label for="file-input" class="text-sm font-medium">Upload file:</label>
             <input id="file-input" type="file" class="text-sm" />
+            <button id="download-history" class="text-xs border px-2 py-1">Download Chat</button>
+            <label for="history-input" class="text-sm font-medium">History:</label>
+            <input id="history-input" type="file" class="text-sm" />
             <button id="clear-chat" class="ml-auto text-xs text-red-500">Clear Chat</button>
         </div>
 

--- a/tests/test_plugin_endpoints_runtime.py
+++ b/tests/test_plugin_endpoints_runtime.py
@@ -1,0 +1,51 @@
+import os
+import httpx
+import pytest
+
+from moogla import server
+from moogla.server import create_app
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+@pytest.mark.asyncio
+async def test_plugin_management_endpoints(monkeypatch, tmp_path):
+    db = tmp_path / "plugins.db"
+    monkeypatch.setenv("MOOGLA_PLUGIN_DB", str(db))
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(db_url=f"sqlite:///{tmp_path}/db.db")
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/plugins")
+        assert resp.status_code == 200
+        assert resp.json()["plugins"] == []
+
+        resp = await client.post("/plugins", json={"name": "tests.dummy_plugin"})
+        assert resp.status_code == 201
+        assert "tests.dummy_plugin" in resp.json()["plugins"]
+
+        resp = await client.post("/v1/completions", json={"prompt": "abc"})
+        assert resp.json()["choices"][0]["text"] == "!!CBA!!"
+
+        resp = await client.delete("/plugins/tests.dummy_plugin")
+        assert resp.status_code == 204
+
+        resp = await client.post("/v1/completions", json={"prompt": "abc"})
+        assert resp.json()["choices"][0]["text"] == "cba"
+
+
+@pytest.mark.asyncio
+async def test_enable_invalid_plugin(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/plugins", json={"name": "no.such.module"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow runtime plugin management through new `/plugins` endpoints
- let the web UI toggle plugins and download or upload chat history
- add unit tests for the new plugin endpoints

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af45c6ba8833281b2333b668d9a80