### PR TITLE
Add DB failure, config, concurrency tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ During development you can run the server with auto reload using `uvicorn`:
 uvicorn moogla.server:create_app --reload
 ```
 
+## Running Tests
+
+Before running the test suite make sure the development extras are installed:
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
 ### Web Interface
 
 To try the browser UI run the server and open the bundled web app:

--- a/tests/test_error_cases.py
+++ b/tests/test_error_cases.py
@@ -1,0 +1,45 @@
+import asyncio
+import os
+import sqlite3
+import httpx
+import pytest
+
+from moogla import server, plugins_config
+
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = server.create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        async def call(n: int):
+            resp = await client.post("/v1/completions", json={"prompt": str(n)})
+            assert resp.status_code == 200
+            return resp.json()["choices"][0]["text"]
+
+        results = await asyncio.gather(*(call(i) for i in range(5)))
+    assert results == [str(i)[::-1] for i in range(5)]
+
+
+def test_invalid_db_url(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    with pytest.raises(Exception):
+        server.create_app(db_url="invalid://foo")
+
+
+def test_plugins_db_connection_error(monkeypatch):
+    def fail_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("fail")
+
+    monkeypatch.setattr(plugins_config.sqlite3, "connect", fail_connect)
+    with pytest.raises(sqlite3.OperationalError):
+        plugins_config.get_plugins()


### PR DESCRIPTION
## Summary
- cover concurrent request handling
- ensure invalid DB URLs raise errors without side effects
- check plugin database connection failures
- document installing dev extras before running `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af45fdab48332bb88378270a2e47c