### PR TITLE
Add plugin configuration file loader

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,10 +22,17 @@ Plugins can be loaded at startup using `--plugin`:
 moogla serve --plugin my_plugin
 ```
 
-You can also persist plugin names using the CLI:
+You can also persist plugin names using the CLI. Plugin information is stored in
+a YAML or JSON file (by default `~/.cache/moogla/plugins.yaml`).
 
 ```bash
 moogla plugin add my_plugin
 moogla plugin list
 moogla plugin remove my_plugin
+```
+
+The file location can be customised with `--config`:
+
+```bash
+moogla plugin --config /path/to/plugins.json add my_plugin
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "sqlmodel>=0.0.24",
     "passlib[bcrypt]>=1.7",
     "python-jose>=3.3",
+    "pyyaml>=6.0",
     "pydantic-settings>=2.0",
 ]
 

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -16,6 +16,20 @@ plugin_app = typer.Typer(help="Manage plugins")
 app.add_typer(plugin_app, name="plugin")
 
 
+@plugin_app.callback()
+def plugin_callback(
+    config: str = typer.Option(
+        None,
+        "--config",
+        help="Path to plugin configuration file",
+        envvar="MOOGLA_PLUGIN_FILE",
+        show_default=False,
+    )
+) -> None:
+    if config:
+        plugins_config.set_plugin_file(config)
+
+
 @plugin_app.command("add")
 def plugin_add(name: str) -> None:
     """Add a plugin to the persistent store."""
@@ -97,11 +111,11 @@ def serve(
         envvar="MOOGLA_JWT_SECRET",
         show_default=False,
     ),
-    plugin_db: str = typer.Option(
+    plugin_file: str = typer.Option(
         None,
-        "--plugin-db",
-        help="Path to plugin configuration DB",
-        envvar="MOOGLA_PLUGIN_DB",
+        "--plugin-file",
+        help="Path to plugin configuration file",
+        envvar="MOOGLA_PLUGIN_FILE",
         show_default=False,
     ),
 ):
@@ -125,7 +139,7 @@ def serve(
         redis_url=redis_url,
         db_url=db_url,
         jwt_secret=jwt_secret,
-        plugin_db=plugin_db,
+        plugin_file=plugin_file,
     )
 
 

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     rate_limit: Optional[int] = Field(None, env="MOOGLA_RATE_LIMIT")
     redis_url: str = Field("redis://localhost:6379", env="MOOGLA_REDIS_URL")
     db_url: str = Field("sqlite:///:memory:", env="MOOGLA_DB_URL")
-    plugin_db: Optional[Path] = Field(None, env="MOOGLA_PLUGIN_DB")
+    plugin_file: Optional[Path] = Field(None, env="MOOGLA_PLUGIN_FILE")
     jwt_secret: str = Field("secret", env="MOOGLA_JWT_SECRET")
     model_dir: Path = Field(
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -37,7 +37,7 @@ def create_app(
     rate_limit: Optional[int] = None,
     redis_url: Optional[str] = None,
     db_url: Optional[str] = None,
-    plugin_db: Optional[str] = None,
+    plugin_file: Optional[str] = None,
     jwt_secret: Optional[str] = None,
 ) -> FastAPI:
     """Build the FastAPI application."""
@@ -50,14 +50,12 @@ def create_app(
         rate_limit = settings.rate_limit
     redis_url = redis_url or settings.redis_url
     db_url = db_url or settings.db_url
-    plugin_db = plugin_db or settings.plugin_db
+    plugin_file = plugin_file or settings.plugin_file
     secret_key = jwt_secret or settings.jwt_secret
     algorithm = "HS256"
 
-    if plugin_db is None and db_url and db_url.startswith("sqlite:///"):
-        plugin_db = Path(db_url.replace("sqlite:///", ""))
-    if plugin_db:
-        plugins_config.set_plugin_db(str(plugin_db))
+    if plugin_file:
+        plugins_config.set_plugin_file(str(plugin_file))
 
     plugins = load_plugins(plugin_names)
 
@@ -244,7 +242,7 @@ def start_server(
     rate_limit: Optional[int] = None,
     redis_url: Optional[str] = None,
     db_url: Optional[str] = None,
-    plugin_db: Optional[str] = None,
+    plugin_file: Optional[str] = None,
     jwt_secret: Optional[str] = None,
 ) -> None:
     """Run the HTTP server."""
@@ -257,7 +255,7 @@ def start_server(
         rate_limit=rate_limit,
         redis_url=redis_url,
         db_url=db_url,
-        plugin_db=plugin_db,
+        plugin_file=plugin_file,
         jwt_secret=jwt_secret,
     )
     uvicorn.run(app, host=host, port=port)

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -9,8 +9,8 @@ runner = CliRunner()
 
 
 def test_cli_plugin_management(tmp_path, monkeypatch):
-    db = tmp_path / "plugins.db"
-    monkeypatch.setenv("MOOGLA_PLUGIN_DB", str(db))
+    cfg = tmp_path / "plugins.yaml"
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
 
     result = runner.invoke(app, ["plugin", "add", "tests.dummy_plugin"])
     assert result.exit_code == 0
@@ -37,8 +37,8 @@ class DummyExecutor:
 
 
 def test_persisted_plugins_loaded(tmp_path, monkeypatch):
-    db = tmp_path / "plugins.db"
-    monkeypatch.setenv("MOOGLA_PLUGIN_DB", str(db))
+    cfg = tmp_path / "plugins.yaml"
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
     plugins_config.add_plugin("tests.dummy_plugin")
 
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())


### PR DESCRIPTION
## Summary
- support YAML/JSON plugin configuration files
- add `--config/--plugin-file` flags in CLI
- document persistent plugin file usage
- update tests for new loader

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0166e4088332a81dca5847716545