### PR TITLE
Add metrics endpoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,4 @@ site contains user and developer documentation.
 - [Plugin Development](plugins.md)
 - [Authentication](authentication.md)
 - [Web UI](web_ui.md)
+- [Metrics](metrics.md)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,14 @@
+# Metrics
+
+Moogla exposes Prometheus compatible metrics on the `/metrics` endpoint. The
+endpoint uses the same authentication and rate limiting settings as the other
+API routes.
+
+The following metrics are provided:
+
+- `moogla_requests_total` – count of handled requests labeled by path
+- `moogla_request_latency_seconds` – request latency histogram
+- `moogla_tokens_generated_total` – total number of tokens produced
+
+Include your API key or JWT token when scraping the endpoint if authentication
+is enabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "sqlmodel>=0.0.24",
     "passlib[bcrypt]>=1.7",
     "python-jose>=3.3",
+    "prometheus-client>=0.20",
     "pydantic-settings>=2.0",
 ]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+from prometheus_client.parser import text_string_to_metric_families
+
+from moogla import server
+from moogla.server import create_app
+
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def acomplete(self, prompt: str, max_tokens: int = 16) -> str:
+        return prompt[::-1]
+
+    async def astream(self, prompt: str, max_tokens: int = 16):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(server_api_key="secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.post(
+            "/v1/completions",
+            json={"prompt": "abc"},
+            headers={"X-API-Key": "secret"},
+        )
+        resp = await client.get("/metrics", headers={"X-API-Key": "secret"})
+    assert resp.status_code == 200
+    metrics = {f.name: f for f in text_string_to_metric_families(resp.text)}
+    req = next(
+        s for s in metrics["moogla_requests"].samples if s.name == "moogla_requests_total" and s.labels["path"] == "/v1/completions"
+    )
+    assert req.value >= 1
+    assert metrics["moogla_tokens_generated"].samples[0].value >= 1
+
+
+@pytest.mark.asyncio
+async def test_metrics_requires_auth(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(server_api_key="secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/metrics")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add `prometheus-client` to dependencies
- expose `/metrics` endpoint with Prometheus metrics
- count requests, latency, and token usage
- test metrics endpoint and document new feature

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b016850ac8332b078038b306b7b34