### PR TITLE
Add user management endpoints

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,5 +11,9 @@ The API also provides `/register` and `/login` endpoints for JWT based
 authentication. After registration, send the returned token in an
 `Authorization: Bearer <token>` header.
 
+Authenticated clients can list all users via `/users` and change
+passwords using the `/change-password` endpoint. Both require either a
+valid API key or JWT token.
+
 Rate limiting can be enabled with `MOOGLA_RATE_LIMIT` and a Redis
 connection via `MOOGLA_REDIS_URL`.

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -185,6 +185,28 @@ def create_app(
 
     route_args = {"dependencies": [auth_dependency]} if auth_dependency else {}
 
+    class PasswordChange(BaseModel):
+        username: str
+        old_password: str
+        new_password: str
+
+    @app.get("/users", **route_args)
+    def list_users():
+        with Session(engine) as session:
+            users = session.exec(select(User)).all()
+            return [{"id": u.id, "username": u.username} for u in users]
+
+    @app.post("/change-password", **route_args)
+    def change_password(change: PasswordChange):
+        with Session(engine) as session:
+            user = session.exec(select(User).where(User.username == change.username)).first()
+            if not user or not pwd_context.verify(change.old_password, user.hashed_password):
+                raise HTTPException(status_code=400, detail="Invalid credentials")
+            user.hashed_password = pwd_context.hash(change.new_password)
+            session.add(user)
+            session.commit()
+        return {"status": "ok"}
+
     @app.post("/v1/chat/completions", **route_args)
     async def chat_completions(req: ChatRequest):
         """Handle Chat API calls and return a reversed assistant reply."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -61,3 +61,31 @@ async def test_jwt_auth(monkeypatch, tmp_path):
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_user_endpoints(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    db = tmp_path / "db.db"
+    app = create_app(server_api_key="secret", db_url=f"sqlite:///{db}")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/register", json={"username": "u", "password": "p"})
+        assert resp.status_code == 201
+
+        resp = await client.get("/users", headers={"X-API-Key": "secret"})
+        assert resp.status_code == 200
+        assert resp.json() == [{"id": 1, "username": "u"}]
+
+        resp = await client.post(
+            "/change-password",
+            json={"username": "u", "old_password": "p", "new_password": "n"},
+            headers={"X-API-Key": "secret"},
+        )
+        assert resp.status_code == 200
+
+        resp = await client.post("/login", json={"username": "u", "password": "p"})
+        assert resp.status_code == 401
+        resp = await client.post("/login", json={"username": "u", "password": "n"})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow listing users and changing passwords via new endpoints
- document new endpoints in authentication guide
- test user management endpoints

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b016982088332a365d8ca8646acb3