### PR TITLE
Implement chat REPL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ curl -X POST http://localhost:11434/v1/chat/completions \
   -d '{"messages": [{"role": "user", "content": "hello"}]}'
 ```
 
+For a more interactive experience start the built-in REPL:
+
+```bash
+moogla chat
+```
+
+Add `--stream` to display tokens as they are generated.
+
 ### Plugin API
 
 Plugins are regular Python modules that expose optional `preprocess` and


### PR DESCRIPTION
## Summary
- add `moogla chat` command for talking to a running server
- document the REPL usage in README
- test non-streaming and streaming chat

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b016a63fc8332a6515af95966e860