### PR TITLE
Improve security defaults

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,6 +11,13 @@ The API also provides `/register` and `/login` endpoints for JWT based
 authentication. After registration, send the returned token in an
 `Authorization: Bearer <token>` header.
 
+Tokens are signed with `MOOGLA_JWT_SECRET`. If this variable is not set the
+server generates a random value on startup, meaning issued tokens become
+invalid after a restart. Specify a persistent secret in production.
+
+User records are kept in an in-memory SQLite database by default. Set
+`MOOGLA_DB_URL` to use a durable database so accounts survive server restarts.
+
 Authenticated clients can list all users via `/users` and change
 passwords using the `/change-password` endpoint. Both require either a
 valid API key or JWT token.

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
+import secrets
 
 
 class Settings(BaseSettings):
@@ -18,7 +19,10 @@ class Settings(BaseSettings):
     redis_url: str = Field("redis://localhost:6379", env="MOOGLA_REDIS_URL")
     db_url: str = Field("sqlite:///:memory:", env="MOOGLA_DB_URL")
     plugin_file: Optional[Path] = Field(None, env="MOOGLA_PLUGIN_FILE")
-    jwt_secret: str = Field("secret", env="MOOGLA_JWT_SECRET")
+    jwt_secret: str = Field(
+        default_factory=lambda: secrets.token_urlsafe(32),
+        env="MOOGLA_JWT_SECRET",
+    )
     model_dir: Path = Field(
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
         env="MOOGLA_MODEL_DIR",

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from pathlib import Path
 from typing import List, Optional
 from contextlib import asynccontextmanager
@@ -53,6 +54,15 @@ def create_app(
     plugin_file = plugin_file or settings.plugin_file
     secret_key = jwt_secret or settings.jwt_secret
     algorithm = "HS256"
+
+    if jwt_secret is None and "MOOGLA_JWT_SECRET" not in os.environ:
+        logger.warning(
+            "Generated ephemeral JWT secret. Set MOOGLA_JWT_SECRET to persist tokens."
+        )
+    if db_url == "sqlite:///:memory:":
+        logger.warning(
+            "Using in-memory SQLite database; user data will not persist."
+        )
 
     if plugin_file:
         plugins_config.set_plugin_file(str(plugin_file))


### PR DESCRIPTION
## Summary
- randomize `MOOGLA_JWT_SECRET` when not set
- warn when using ephemeral JWT secrets or in-memory DB
- document JWT secret and DB persistence requirements

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b05fc071c83328d06306895bab7fb