### PR TITLE
Support plugin init settings

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -36,3 +36,17 @@ The file location can be customised with `--config`:
 ```bash
 moogla plugin --config /path/to/plugins.json add my_plugin
 ```
+
+Plugins can also define an optional `init` function which receives any
+stored configuration for the plugin. The settings are provided when the
+plugin module is imported:
+
+```python
+# my_plugin.py
+
+def init(settings: dict):
+    print("initialising with", settings)
+```
+
+Settings can be saved programmatically with `plugins_config.add_plugin`
+or by editing the configuration file directly.

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -47,7 +47,7 @@ def plugin_remove(name: str) -> None:
 @plugin_app.command("list")
 def plugin_list() -> None:
     """List configured plugins."""
-    names = plugins_config.get_plugins()
+    names, _ = plugins_config.get_plugins()
     if not names:
         typer.echo("No plugins configured")
     else:

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -1,7 +1,7 @@
 import os
 import json
 from pathlib import Path
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 
 import yaml
 
@@ -43,14 +43,24 @@ def _save(data: Dict[str, Any]) -> None:
             json.dump(data, f, indent=2)
 
 
-def get_plugins() -> List[str]:
+def get_plugins() -> Tuple[List[str], Dict[str, Dict[str, Any]]]:
     data = _load()
     plugins = data.get("plugins")
     if isinstance(plugins, list):
-        return plugins
-    if isinstance(data, list):
-        return data
-    return []
+        names = plugins
+    elif isinstance(data, list):
+        names = data
+    else:
+        names = []
+
+    settings: Dict[str, Dict[str, Any]] = {}
+    raw_settings = data.get("settings")
+    if isinstance(raw_settings, dict):
+        for key, value in raw_settings.items():
+            if isinstance(value, dict):
+                settings[key] = value
+
+    return names, settings
 
 
 def add_plugin(name: str, **settings: Any) -> None:

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -67,7 +67,8 @@ def create_app(
     if plugin_file:
         plugins_config.set_plugin_file(str(plugin_file))
 
-    plugins = load_plugins(plugin_names)
+    _, stored_settings = plugins_config.get_plugins()
+    plugins = load_plugins(plugin_names, stored_settings)
 
     executor = LLMExecutor(model=model, api_key=api_key, api_base=api_base)
 

--- a/tests/settings_plugin.py
+++ b/tests/settings_plugin.py
@@ -1,0 +1,15 @@
+settings_received = None
+
+def init(settings: dict):
+    global settings_received
+    settings_received = settings
+
+
+def preprocess(text: str) -> str:
+    prefix = settings_received.get("prefix", "") if settings_received else ""
+    return prefix + text
+
+
+def postprocess(text: str) -> str:
+    suffix = settings_received.get("suffix", "") if settings_received else ""
+    return text + suffix


### PR DESCRIPTION
## Summary
- return plugin names and settings from `plugins_config.get_plugins`
- initialize plugins via new `init(settings)` hook
- wire plugin settings through server
- document the `init` hook
- test that stored plugin settings are passed during startup

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0d7446188332aeaf81fb4b27b510