### PR TITLE
Add AsyncLlama support

### DIFF
--- a/docs/local_models.md
+++ b/docs/local_models.md
@@ -1,5 +1,14 @@
 # Local Models
 
-Moogla can load GGUF or GGML files through `llama-cpp-python` as well as models from the Hugging Face hub. The `llama-cpp-python` package only exposes synchronous APIs. When the server runs with a local model, calls to `LLMExecutor.acomplete` are executed in a thread using `asyncio.to_thread`.
+Moogla can load GGUF or GGML files through `llama-cpp-python` as well as models
+from the Hugging Face hub. Older releases of `llama-cpp-python` expose only
+synchronous APIs. In that case `LLMExecutor.acomplete` falls back to
+`asyncio.to_thread` to keep the HTTP API responsive.
 
-While this keeps the HTTP API asynchronous, heavy inference will still occupy a worker thread and may reduce overall concurrency. If you rely on high throughput you should consider an async capable backend such as OpenAI's API.
+Recent versions provide an `AsyncLlama` class which Moogla will use
+automatically when available. This avoids blocking the event loop when running
+local models.
+
+While `asyncio.to_thread` keeps the API asynchronous, heavy inference will still
+occupy a worker thread and may reduce overall concurrency. If you rely on high
+throughput you should consider an async capable backend such as OpenAI's API.

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -19,6 +19,7 @@ class LLMExecutor:
         self.async_client = None
         self.generator = None
         self.llama = None
+        self.async_llama = None
 
         key = api_key
 
@@ -26,11 +27,18 @@ class LLMExecutor:
         if model_path.exists() or "/" in model:
             if model_path.suffix in {".gguf", ".ggml", ".bin"}:
                 try:
-                    from llama_cpp import Llama
+                    import llama_cpp  # type: ignore
                 except Exception as exc:  # pragma: no cover - optional dep
                     raise RuntimeError("llama-cpp-python required for GGUF models") from exc
 
-                self.llama = Llama(model_path=str(model_path))
+                AsyncLlama = getattr(llama_cpp, "AsyncLlama", None)
+                Llama = getattr(llama_cpp, "Llama", None)
+                if AsyncLlama is not None:
+                    self.async_llama = AsyncLlama(model_path=str(model_path))
+                else:
+                    if Llama is None:
+                        raise RuntimeError("llama-cpp-python required for GGUF models")
+                    self.llama = Llama(model_path=str(model_path))
             else:
                 try:
                     from transformers import pipeline
@@ -172,6 +180,16 @@ class LLMExecutor:
                     yield delta
             return
 
+        if self.async_llama:
+            result = await self.async_llama(
+                prompt, max_tokens=max_tokens, stream=True
+            )
+            async for chunk in result:
+                text = chunk.get("choices", [{}])[0].get("text")
+                if text:
+                    yield text
+            return
+
         for token in self.stream(
             prompt,
             max_tokens=max_tokens,
@@ -205,8 +223,14 @@ class LLMExecutor:
             )
             return response.choices[0].message.content
 
-        # ``llama_cpp`` exposes only synchronous APIs so local inference can
-        # block the event loop.  Run any non-async backends in a thread.
+        if self.async_llama:
+            result = await self.async_llama(
+                prompt, max_tokens=max_tokens
+            )
+            return result["choices"][0]["text"]
+
+        # Some backends expose only synchronous APIs so local inference can
+        # block the event loop. Run them in a thread.
         if self.llama or self.generator or self.client:
             return await asyncio.to_thread(
                 self.complete,

--- a/tests/test_async_llama.py
+++ b/tests/test_async_llama.py
@@ -1,0 +1,42 @@
+import asyncio
+import sys
+import types
+import pytest
+
+from moogla.executor import LLMExecutor
+
+class DummyAsyncLlama:
+    def __init__(self, model_path: str) -> None:
+        self.model_path = model_path
+
+    async def __call__(self, prompt: str, max_tokens: int = 16, stream: bool = False):
+        if stream:
+            async def gen():
+                for ch in prompt[::-1]:
+                    yield {"choices": [{"text": ch}]}
+            return gen()
+        return {"choices": [{"text": prompt[::-1]}]}
+
+@pytest.mark.asyncio
+async def test_async_llama_usage(monkeypatch):
+    dummy_module = types.SimpleNamespace(AsyncLlama=DummyAsyncLlama, Llama=DummyAsyncLlama)
+    monkeypatch.setitem(sys.modules, "llama_cpp", dummy_module)
+
+    called = False
+
+    async def fake_to_thread(func, *args, **kwargs):
+        nonlocal called
+        called = True
+        return await func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    executor = LLMExecutor(model="some/model.gguf")
+
+    result = await executor.acomplete("abc")
+    assert result == "cba"
+    assert called is False
+
+    tokens = [t async for t in executor.astream("abc")]
+    assert tokens == list("cba")
+    assert called is False


### PR DESCRIPTION
## Summary
- detect `llama_cpp.AsyncLlama` in `LLMExecutor`
- use async llama for async methods when available
- test async execution with mocked `AsyncLlama`
- document improved local model async behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b0d767a00833296ab5c7a51717db0