### PR TITLE
Clarify plugin configuration location

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ return the modified value.
 A plugin can specify an integer `order` attribute to control execution order
 when multiple plugins are loaded. Lower numbers run first.
 
+Plugin information is stored in `~/.cache/moogla/plugins.yaml` by default.
+Use `--config` or the `MOOGLA_PLUGIN_FILE` environment variable to point
+to a different location:
+
+```bash
+MOOGLA_PLUGIN_FILE=/opt/plugins.json moogla plugin list
+```
+
 ### Async Limitations
 
 Local models loaded through `llama-cpp-python` do not expose an asynchronous

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -31,8 +31,11 @@ moogla plugin list
 moogla plugin remove my_plugin
 ```
 
-The file location can be customised with `--config`:
+The file location can be customised with the `--config` option or the
+`MOOGLA_PLUGIN_FILE` environment variable. Both override the default
+path for all plugin commands:
 
 ```bash
-moogla plugin --config /path/to/plugins.json add my_plugin
+export MOOGLA_PLUGIN_FILE=/path/to/plugins.json
+moogla plugin add my_plugin
 ```


### PR DESCRIPTION
## Summary
- document how to override the plugin config file path
- show a plugin config example in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0d78ccb08332921076485c39b680