### PR TITLE
Add plugin settings support

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -39,3 +39,36 @@ path for all plugin commands:
 export MOOGLA_PLUGIN_FILE=/path/to/plugins.json
 moogla plugin add my_plugin
 ```
+
+## Plugin Settings
+
+Additional options for a plugin can be stored alongside its name in the
+configuration file. When a plugin defines a `setup(settings: dict)` function,
+those settings are passed to it on load.
+
+Example YAML structure:
+
+```yaml
+plugins:
+  - my_plugin
+settings:
+  my_plugin:
+    greeting: hello
+```
+
+Within the plugin you can read the settings during setup:
+
+```python
+# my_plugin.py
+config = {}
+
+def setup(settings: dict) -> None:
+    config.update(settings)
+
+def preprocess(text: str) -> str:
+    return f"{config.get('greeting', '')}{text}"
+```
+
+Settings are automatically provided when running `moogla serve` or creating the
+application programmatically.
+

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -56,6 +56,16 @@ def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
         except Exception as exc:
             logger.error("Failed to import plugin '%s': %s", name, exc)
             raise ImportError(f"Cannot import plugin '{name}'") from exc
+
+        settings = plugins_config.get_plugin_settings(name)
+        setup_func = getattr(module, "setup", None)
+        if setup_func:
+            try:
+                setup_func(settings)
+            except Exception as exc:  # pragma: no cover - pass through
+                logger.error("Failed to setup plugin '%s': %s", name, exc)
+                raise
+
         plugins.append(Plugin(module))
 
     plugins.sort(key=lambda p: p.order)

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -77,3 +77,14 @@ def remove_plugin(name: str) -> None:
     if isinstance(data.get("settings"), dict):
         data["settings"].pop(name, None)
     _save(data)
+
+def get_plugin_settings(name: str) -> Dict[str, Any]:
+    """Return stored settings for the given plugin."""
+    data = _load()
+    settings = data.get("settings")
+    if isinstance(settings, dict):
+        value = settings.get(name)
+        if isinstance(value, dict):
+            return value
+    return {}
+

--- a/tests/setup_plugin.py
+++ b/tests/setup_plugin.py
@@ -1,0 +1,12 @@
+configured = {}
+
+
+def setup(settings: dict) -> None:
+    configured.clear()
+    configured.update(settings)
+
+
+def postprocess(text: str) -> str:
+    suffix = configured.get("suffix", "")
+    return f"{text}{suffix}"
+

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -58,3 +58,23 @@ def test_persisted_plugins_loaded(tmp_path, monkeypatch):
     resp = client.post("/v1/completions", json={"prompt": "abc"})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["text"] == "!!CBA!!"
+
+
+def test_plugin_settings_used(tmp_path, monkeypatch):
+    cfg = tmp_path / "plugins.yaml"
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
+    plugins_config.add_plugin("tests.setup_plugin", suffix="??")
+
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app_instance = server.create_app()
+
+    import importlib
+
+    setup_plugin = importlib.import_module("tests.setup_plugin")
+    assert setup_plugin.configured == {"suffix": "??"}
+
+    client = TestClient(app_instance)
+    resp = client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "cba??"
+


### PR DESCRIPTION
## Summary
- store and retrieve plugin settings
- call plugin `setup()` during loading
- document plugin settings
- test that stored settings are passed to plugin

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b164b176c8332b840d81ca87cf56f