### PR TITLE
Add configurable JWT expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ record, then call `/login` with the same credentials to obtain a token.
 Include this token in an `Authorization: Bearer <token>` header when calling the
 LLM routes. Tokens are signed with a random secret and stored in an in-memory
 SQLite database by default. Set `MOOGLA_JWT_SECRET` and `MOOGLA_DB_URL` to keep
-credentials valid across restarts. Authentication support relies on the
+credentials valid across restarts. `MOOGLA_TOKEN_EXP_MINUTES` controls how long
+issued tokens remain valid (default `30`). Authentication support relies on the
 `SQLModel`, `passlib` and `python-jose` packages.
 
 ## Running with Docker

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -15,6 +15,9 @@ Tokens are signed with `MOOGLA_JWT_SECRET`. If this variable is not set the
 server generates a random value on startup, meaning issued tokens become
 invalid after a restart. Specify a persistent secret in production.
 
+`MOOGLA_TOKEN_EXP_MINUTES` configures the token lifetime in minutes. The
+default is `30`.
+
 User records are kept in an in-memory SQLite database by default. Set
 `MOOGLA_DB_URL` to use a durable database so accounts survive server restarts.
 

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
         default_factory=lambda: secrets.token_urlsafe(32),
         env="MOOGLA_JWT_SECRET",
     )
+    token_exp_minutes: int = Field(30, env="MOOGLA_TOKEN_EXP_MINUTES")
     model_dir: Path = Field(
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
         env="MOOGLA_MODEL_DIR",


### PR DESCRIPTION
## Summary
- add `token_exp_minutes` option to `Settings`
- support token expiration in `create_app` and `start_server`
- document `MOOGLA_TOKEN_EXP_MINUTES`
- test JWT expiration logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b164be74c8332a8eba42f2c1497bc