### PR TITLE
Document model directory setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Pull a model and start the server with a custom plugin:
 moogla pull codellama:13b
 moogla serve --model path/to/codellama-13b.gguf --plugin tests.dummy_plugin
 ```
+Models are stored under `~/.cache/moogla/models` by default. Set `MOOGLA_MODEL_DIR` before running the pull command to use a different directory.
 
 To use a Hugging Face model ID instead of a file path:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,3 +18,9 @@ Run the CLI to see available commands:
 ```bash
 moogla --help
 ```
+
+### Models Directory
+
+By default `moogla pull` stores downloaded models in `~/.cache/moogla/models`.
+Set `MOOGLA_MODEL_DIR` to choose a different location. All commands that use
+local models will look for files in this directory.


### PR DESCRIPTION
## Summary
- describe the `MOOGLA_MODEL_DIR` environment variable in the setup docs
- mention the variable in README getting started instructions

## Testing
- `pre-commit run --files README.md docs/setup.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b164d3f048332b9cd782124d38e4c