### PR TITLE
Update pull CLI option

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -148,8 +148,8 @@ def serve(
 @app.command()
 def pull(
     model: str,
-    dir: Path = typer.Option(
-        None, "--dir", "-d", help="Directory for downloaded models"
+    out_dir: Path = typer.Option(
+        None, "--out-dir", "-d", help="Directory for downloaded models"
     ),
 ):
     """Download a model into the local cache.
@@ -157,10 +157,10 @@ def pull(
     Parameters
     ----------
     model: Identifier, path or URL of the model to fetch.
-    dir: Target directory for the downloaded file.
+    out_dir: Target directory for the downloaded file.
     """
     settings = Settings()
-    dest_dir = dir or settings.model_dir
+    dest_dir = out_dir or settings.model_dir
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     parsed = urlparse(model)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,7 @@ def test_pull_downloads_to_custom_dir():
         src.write_text("hi")
 
         with tempfile.TemporaryDirectory() as target_dir:
-            result = runner.invoke(app, ["pull", str(src), "--dir", target_dir])
+            result = runner.invoke(app, ["pull", str(src), "--out-dir", target_dir])
             assert result.exit_code == 0
             assert (Path(target_dir) / "dummy.txt").exists()
 
@@ -121,7 +121,7 @@ def test_pull_http_error(monkeypatch, tmp_path):
     monkeypatch.setattr(httpx, "stream", fake_stream)
 
     result = runner.invoke(
-        app, ["pull", "http://example.com/x.bin", "--dir", str(tmp_path)]
+        app, ["pull", "http://example.com/x.bin", "--out-dir", str(tmp_path)]
     )
     assert result.exit_code == 1
     assert not (tmp_path / "x.bin").exists()


### PR DESCRIPTION
## Summary
- rename `dir` parameter in `pull` command to `out_dir`
- use `out_dir` to set `dest_dir`
- update CLI option name in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1e4b8ccc833287b857ead203de36