### PR TITLE
Fix async streaming for sync backends

### DIFF
--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -195,13 +195,22 @@ class LLMExecutor:
                     yield text
             return
 
-        for token in self.stream(
-            prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-        ):
-            yield token
+        if self.llama or self.generator or self.client:
+            tokens = await asyncio.to_thread(
+                lambda: list(
+                    self.stream(
+                        prompt,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                    )
+                )
+            )
+            for token in tokens:
+                yield token
+            return
+
+        raise RuntimeError("No LLM backend configured")
 
     async def acomplete(
         self,


### PR DESCRIPTION
## Summary
- handle sync-only LLM backends in `LLMExecutor.astream` using `asyncio.to_thread`
- add regression test for streaming with a synchronous backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b26366e2c8332bb1f959e4c1d6c7a