### PR TITLE
Switch to Pydantic validation_alias

### DIFF
--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -11,22 +11,24 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
-    model: str = Field("gpt-3.5-turbo", env="MOOGLA_MODEL")
-    openai_api_key: Optional[str] = Field(None, env="OPENAI_API_KEY")
-    openai_api_base: Optional[str] = Field(None, env="OPENAI_API_BASE")
-    server_api_key: Optional[str] = Field(None, env="MOOGLA_API_KEY")
-    rate_limit: Optional[int] = Field(None, env="MOOGLA_RATE_LIMIT")
-    redis_url: str = Field("redis://localhost:6379", env="MOOGLA_REDIS_URL")
-    db_url: str = Field("sqlite:///:memory:", env="MOOGLA_DB_URL")
-    plugin_file: Optional[Path] = Field(None, env="MOOGLA_PLUGIN_FILE")
+    model: str = Field("gpt-3.5-turbo", validation_alias="MOOGLA_MODEL")
+    openai_api_key: Optional[str] = Field(None, validation_alias="OPENAI_API_KEY")
+    openai_api_base: Optional[str] = Field(None, validation_alias="OPENAI_API_BASE")
+    server_api_key: Optional[str] = Field(None, validation_alias="MOOGLA_API_KEY")
+    rate_limit: Optional[int] = Field(None, validation_alias="MOOGLA_RATE_LIMIT")
+    redis_url: str = Field(
+        "redis://localhost:6379", validation_alias="MOOGLA_REDIS_URL"
+    )
+    db_url: str = Field("sqlite:///:memory:", validation_alias="MOOGLA_DB_URL")
+    plugin_file: Optional[Path] = Field(None, validation_alias="MOOGLA_PLUGIN_FILE")
     jwt_secret: str = Field(
         default_factory=lambda: secrets.token_urlsafe(32),
-        env="MOOGLA_JWT_SECRET",
+        validation_alias="MOOGLA_JWT_SECRET",
     )
-    token_exp_minutes: int = Field(30, env="MOOGLA_TOKEN_EXP_MINUTES")
+    token_exp_minutes: int = Field(30, validation_alias="MOOGLA_TOKEN_EXP_MINUTES")
     model_dir: Path = Field(
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
-        env="MOOGLA_MODEL_DIR",
+        validation_alias="MOOGLA_MODEL_DIR",
     )
 
     model_config = SettingsConfigDict(env_prefix="")


### PR DESCRIPTION
## Summary
- use `validation_alias` in configuration instead of deprecated `env`
- keep `env_prefix` settings for Pydantic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2a016e248332910d83b4bf8bedd8