### PR TITLE
Change CLI dir option to directory

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -148,8 +148,11 @@ def serve(
 @app.command()
 def pull(
     model: str,
-    dir: Path = typer.Option(
-        None, "--dir", "-d", help="Directory for downloaded models"
+    directory: Path = typer.Option(
+        None,
+        "--directory",
+        "-d",
+        help="Directory to save downloaded models",
     ),
 ):
     """Download a model into the local cache.
@@ -157,10 +160,10 @@ def pull(
     Parameters
     ----------
     model: Identifier, path or URL of the model to fetch.
-    dir: Target directory for the downloaded file.
+    directory: Target directory for the downloaded file.
     """
     settings = Settings()
-    dest_dir = dir or settings.model_dir
+    dest_dir = directory or settings.model_dir
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     parsed = urlparse(model)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,7 @@ def test_pull_downloads_to_custom_dir():
         src.write_text("hi")
 
         with tempfile.TemporaryDirectory() as target_dir:
-            result = runner.invoke(app, ["pull", str(src), "--dir", target_dir])
+            result = runner.invoke(app, ["pull", str(src), "--directory", target_dir])
             assert result.exit_code == 0
             assert (Path(target_dir) / "dummy.txt").exists()
 
@@ -121,7 +121,7 @@ def test_pull_http_error(monkeypatch, tmp_path):
     monkeypatch.setattr(httpx, "stream", fake_stream)
 
     result = runner.invoke(
-        app, ["pull", "http://example.com/x.bin", "--dir", str(tmp_path)]
+        app, ["pull", "http://example.com/x.bin", "--directory", str(tmp_path)]
     )
     assert result.exit_code == 1
     assert not (tmp_path / "x.bin").exists()


### PR DESCRIPTION
## Summary
- rename the `dir` option to `directory` in the `pull` command
- update tests for new option name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2a02cea4833281de8a0560837c08