### PR TITLE
Add Ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
   hooks:
     - id: flake8
       args: [--max-line-length=88, --extend-ignore=E203]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.10
+  hooks:
+    - id: ruff


### PR DESCRIPTION
## Summary
- add Ruff linting hook to the pre-commit configuration

## Testing
- `pre-commit run --files src/moogla/executor.py` *(fails: ruff identifies style errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b2a04132c83329d140a98076bd9cb