### PR TITLE
Add models command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ modular, observable and developer friendly.
 - Redis‑backed rate limiting
 - Built‑in dark‑mode web UI with file uploads and quick hints
 - Command to download models for offline use
+- Command to list available local models
 - Docker setup for containerised deployment
 - Example tests demonstrating extensibility
 
@@ -59,6 +60,12 @@ moogla pull codellama:13b
 moogla serve --model path/to/codellama-13b.gguf --plugin tests.dummy_plugin
 ```
 Models are stored under `~/.cache/moogla/models` by default. Set `MOOGLA_MODEL_DIR` before running the pull command to use a different directory.
+
+List downloaded files with:
+
+```bash
+moogla models
+```
 
 To use a Hugging Face model ID instead of a file path:
 

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -210,5 +210,22 @@ def pull(
     typer.echo(f"\nSaved to {dest}")
 
 
+@app.command()
+def models() -> None:
+    """List model files in the configured directory."""
+    settings = Settings()
+    model_dir = settings.model_dir
+    if not model_dir.is_dir():
+        typer.echo("No models found")
+        return
+
+    names = sorted(p.name for p in model_dir.iterdir() if p.is_file())
+    if not names:
+        typer.echo("No models found")
+    else:
+        for n in names:
+            typer.echo(n)
+
+
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ def test_help():
     assert result.exit_code == 0
     assert "serve" in result.output
     assert "pull" in result.output
+    assert "models" in result.output
 
 
 def test_serve_with_plugin(monkeypatch):
@@ -126,3 +127,17 @@ def test_pull_http_error(monkeypatch, tmp_path):
     assert result.exit_code == 1
     assert not (tmp_path / "x.bin").exists()
     assert "Failed to download" in result.output
+
+
+def test_models_lists_files(tmp_path, monkeypatch):
+    models_dir = tmp_path / ".cache" / "moogla" / "models"
+    models_dir.mkdir(parents=True)
+    (models_dir / "a.bin").write_text("hi")
+    (models_dir / "b.gguf").write_text("ok")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["models"])
+    assert result.exit_code == 0
+    assert "a.bin" in result.output
+    assert "b.gguf" in result.output


### PR DESCRIPTION
## Summary
- add `models` command to list local models
- document the command in README
- test the new behaviour

## Testing
- `pre-commit run --files src/moogla/cli.py tests/test_cli.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2a04d1108332ba8d9db80a70ba59