### PR TITLE
Fix async plugin setup with active loop

### DIFF
--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import logging
+import threading
 from importlib import import_module
 from types import ModuleType
 from typing import Callable, List, Optional
@@ -71,7 +72,29 @@ def load_plugins(names: Optional[List[str]]) -> List[Plugin]:
         if setup_async:
             try:
                 if inspect.iscoroutinefunction(setup_async):
-                    asyncio.run(setup_async(settings))
+                    try:
+                        asyncio.get_running_loop()
+                    except RuntimeError:
+                        asyncio.run(setup_async(settings))
+                    else:
+                        loop = asyncio.new_event_loop()
+                        exc: Optional[BaseException] = None
+
+                        def runner() -> None:
+                            nonlocal exc
+                            asyncio.set_event_loop(loop)
+                            try:
+                                loop.run_until_complete(setup_async(settings))
+                            except BaseException as e:
+                                exc = e
+                            finally:
+                                loop.close()
+
+                        thread = threading.Thread(target=runner)
+                        thread.start()
+                        thread.join()
+                        if exc:
+                            raise exc
                 else:
                     setup_async(settings)
             except Exception as exc:  # pragma: no cover - pass through

--- a/tests/test_async_setup_plugin.py
+++ b/tests/test_async_setup_plugin.py
@@ -1,22 +1,42 @@
-import os
 import importlib
-from fastapi.testclient import TestClient
-import pytest
+import os
 
-from moogla import server, plugins_config
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from moogla import plugins_config, server
 from moogla.server import create_app
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 
 class DummyExecutor:
-    def complete(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None) -> str:
+    def complete(
+        self,
+        prompt: str,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ) -> str:
         return prompt[::-1]
 
-    async def acomplete(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None) -> str:
+    async def acomplete(
+        self,
+        prompt: str,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ) -> str:
         return prompt[::-1]
 
-    async def astream(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None):
+    async def astream(
+        self,
+        prompt: str,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ):
         text = prompt[::-1]
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
@@ -37,3 +57,25 @@ def test_async_setup_called(tmp_path, monkeypatch):
     resp = client.post("/v1/completions", json={"prompt": "abc"})
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["text"] == "cba##"
+    plugins_config.set_plugin_file(None)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_inside_running_loop(tmp_path, monkeypatch):
+    cfg = tmp_path / "plugins.yaml"
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
+    plugins_config.add_plugin("tests.async_setup_plugin", suffix="@@")
+
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app()
+
+    async_setup_plugin = importlib.import_module("tests.async_setup_plugin")
+    assert async_setup_plugin.configured == {"suffix": "@@"}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["text"] == "cba@@"
+    plugins_config.set_plugin_file(None)


### PR DESCRIPTION
## Summary
- detect active event loop when running plugin `setup_async`
- run setup coroutine in a separate event loop thread
- add regression test for creating the app while a loop is running

## Testing
- `black src/moogla/plugins.py tests/test_async_setup_plugin.py`
- `isort src/moogla/plugins.py tests/test_async_setup_plugin.py`
- `flake8 src/moogla/plugins.py tests/test_async_setup_plugin.py`
- `ruff check src/moogla/plugins.py tests/test_async_setup_plugin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b6f38e8008332b46307669f987c53