### PR TITLE
Add models listing endpoint

### DIFF
--- a/src/moogla/web/app.js
+++ b/src/moogla/web/app.js
@@ -8,18 +8,24 @@ const hintsContainer = document.getElementById('hints');
 const clearBtn = document.getElementById('clear-chat');
 const toggleDarkBtn = document.getElementById('toggle-dark');
 
-const models = ['default', 'codellama:13b'];
 const plugins = ['tests.dummy_plugin'];
 const hints = ['Summarize the text', 'List key points', 'Explain it simply'];
 let history = [];
 
-function loadModels() {
-    models.forEach(m => {
-        const opt = document.createElement('option');
-        opt.value = m;
-        opt.textContent = m;
-        modelSelect.appendChild(opt);
-    });
+async function loadModels() {
+    try {
+        const resp = await fetch('/models');
+        const data = await resp.json();
+        const list = data.models || data;
+        list.forEach(m => {
+            const opt = document.createElement('option');
+            opt.value = m;
+            opt.textContent = m;
+            modelSelect.appendChild(opt);
+        });
+    } catch {
+        // ignore fetch errors and leave list empty
+    }
     const savedModel = localStorage.getItem('model');
     if (savedModel) modelSelect.value = savedModel;
     modelSelect.addEventListener('change', () => {
@@ -166,7 +172,7 @@ toggleDarkBtn.addEventListener('click', () => {
     localStorage.setItem('darkMode', enabled ? '1' : '0');
 });
 
-loadModels();
+loadModels().catch(() => {});
 loadPlugins();
 loadHistory();
 loadHints();


### PR DESCRIPTION
## Summary
- expose `/models` HTTP endpoint in the FastAPI server
- fetch model names on page load so `<select>` is populated dynamically
- test the new endpoint

## Testing
- `pytest tests/test_basic.py tests/test_endpoints.py::test_models_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6f397ddc833296903a1164037b8b