### PR TITLE
Add download endpoint and UI button

### DIFF
--- a/src/moogla/web/app.js
+++ b/src/moogla/web/app.js
@@ -7,6 +7,7 @@ const fileInput = document.getElementById('file-input');
 const hintsContainer = document.getElementById('hints');
 const clearBtn = document.getElementById('clear-chat');
 const toggleDarkBtn = document.getElementById('toggle-dark');
+const downloadBtn = document.getElementById('download-app');
 
 const models = ['default', 'codellama:13b'];
 const plugins = ['tests.dummy_plugin'];
@@ -164,6 +165,10 @@ clearBtn.addEventListener('click', () => {
 toggleDarkBtn.addEventListener('click', () => {
     const enabled = document.documentElement.classList.toggle('dark');
     localStorage.setItem('darkMode', enabled ? '1' : '0');
+});
+
+downloadBtn.addEventListener('click', () => {
+    window.location.href = '/download-app';
 });
 
 loadModels();

--- a/src/moogla/web/index.html
+++ b/src/moogla/web/index.html
@@ -15,7 +15,10 @@
     <div class="container mx-auto max-w-xl space-y-4">
         <div class="flex items-center justify-between">
             <h1 class="text-2xl font-bold">Moogla Chat</h1>
-            <button id="toggle-dark" class="text-xs border rounded px-2 py-1">Dark</button>
+            <div class="space-x-2">
+                <button id="download-app" class="text-xs border rounded px-2 py-1">Download</button>
+                <button id="toggle-dark" class="text-xs border rounded px-2 py-1">Dark</button>
+            </div>
         </div>
 
         <div class="flex items-center space-x-2">

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -169,3 +169,10 @@ def test_root_endpoint():
     resp = client.get("/")
     assert resp.status_code == 200
     assert "Moogla Chat" in resp.text
+
+
+def test_download_endpoint_missing():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/download-app")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add `/download-app` endpoint to serve packaged files if present
- expose a new **Download** button in the web UI
- hook button to new endpoint with JavaScript
- test endpoint returns 404 when package is missing

## Testing
- `pre-commit run --files src/moogla/server.py src/moogla/web/index.html src/moogla/web/app.js tests/test_endpoints.py`
- `pytest tests/test_endpoints.py -k download_endpoint_missing -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685b7419926c833282fd07b17af59226