### PR TITLE
Add download packaging feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,18 @@ Full documentation is available on GitHub Pages and can be built locally with:
 mkdocs serve
 ```
 
+## Packaging
+
+Create a standalone binary using `pyinstaller`:
+
+```bash
+pip install pyinstaller
+./scripts/build_package.sh dist/moogla.exe
+```
+
+Place the resulting file under `dist/` so `/download` can serve it.
+
+
 
 
 ## Contributing Guidelines

--- a/docs/web_ui.md
+++ b/docs/web_ui.md
@@ -9,4 +9,5 @@ moogla serve
 ```
 
 Double click a chat bubble to copy its text. Use the dark‑mode toggle in
-the header to switch themes.
+the header to switch themes. A **Download** link is also available for
+retrieving a packaged executable when one has been built.

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 OUTPUT" >&2
+    exit 1
+fi
+
+if ! command -v pyinstaller >/dev/null 2>&1; then
+    echo "pyinstaller is required. Install with pip install pyinstaller." >&2
+    exit 1
+fi
+
+OUTPUT=$1
+pyinstaller --onefile --name moogla src/moogla/cli.py
+mkdir -p "$(dirname "$OUTPUT")"
+cp "dist/moogla" "$OUTPUT"
+echo "Package created at $OUTPUT"

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -151,6 +151,20 @@ def create_app(
         names = sorted(p.name for p in model_dir_path.iterdir() if p.is_file())
         return {"models": names}
 
+    @app.get("/download")
+    def download_package():
+        """Return the packaged application archive if present."""
+        dist_dir = Path(
+            os.getenv(
+                "MOOGLA_DIST_DIR", str(Path(__file__).resolve().parent.parent / "dist")
+            )
+        )
+        for name in ("moogla.dmg", "moogla.exe"):
+            path = dist_dir / name
+            if path.is_file():
+                return FileResponse(path, filename=name)
+        raise HTTPException(status_code=404, detail="Package not found")
+
     class Credentials(BaseModel):
         username: str
         password: str

--- a/src/moogla/web/index.html
+++ b/src/moogla/web/index.html
@@ -15,7 +15,10 @@
     <div class="container mx-auto max-w-xl space-y-4">
         <div class="flex items-center justify-between">
             <h1 class="text-2xl font-bold">Moogla Chat</h1>
-            <button id="toggle-dark" class="text-xs border rounded px-2 py-1">Dark</button>
+            <div class="space-x-2">
+                <a href="/download" class="text-xs border rounded px-2 py-1">Download</a>
+                <button id="toggle-dark" class="text-xs border rounded px-2 py-1">Dark</button>
+            </div>
         </div>
 
         <div class="flex items-center space-x-2">

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -186,3 +186,14 @@ def test_root_endpoint():
     resp = client.get("/")
     assert resp.status_code == 200
     assert "Moogla Chat" in resp.text
+
+
+def test_download_endpoint(tmp_path, monkeypatch):
+    pkg = tmp_path / "moogla.exe"
+    pkg.write_text("binary")
+    monkeypatch.setenv("MOOGLA_DIST_DIR", str(tmp_path))
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/download")
+    assert resp.status_code == 200
+    assert resp.content == b"binary"


### PR DESCRIPTION
## Summary
- serve a packaged executable when present via `/download`
- surface a Download link in the web UI
- provide a helper script for building an executable
- document packaging workflow and download link
- test new `/download` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b75d4cba88332bc27bbaffc4dc69c