### PR TITLE
Add configurable CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ include an `X-API-Key` header matching the configured value. Optionally set
 When rate limiting is enabled, `MOOGLA_REDIS_URL` controls the Redis connection
 used for tracking request counts (default `redis://localhost:6379`). These values
 can also be passed to `create_app` or `moogla serve`.
+Set `MOOGLA_CORS_ORIGINS` to send CORS headers for a comma-separated list of
+allowed origins.
 
 The API also exposes `/register` and `/login` endpoints for JWT-based
 authentication. POST a username and password to `/register` to persist a user

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -27,3 +27,4 @@ valid API key or JWT token.
 
 Rate limiting can be enabled with `MOOGLA_RATE_LIMIT` and a Redis
 connection via `MOOGLA_REDIS_URL`.
+Set `MOOGLA_CORS_ORIGINS` to enable CORS for a comma separated list of origins.

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -30,5 +30,8 @@ class Settings(BaseSettings):
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
         validation_alias="MOOGLA_MODEL_DIR",
     )
+    cors_origins: Optional[str] = Field(
+        None, validation_alias="MOOGLA_CORS_ORIGINS"
+    )
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,27 @@
+import httpx
+import pytest
+
+from moogla import server
+from moogla.server import create_app
+
+
+class DummyExecutor:
+    def complete(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
+        return prompt
+
+    async def acomplete(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
+        return prompt
+
+    async def astream(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
+        yield prompt
+
+
+@pytest.mark.asyncio
+async def test_cors_headers(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(cors_origins="http://example.com")
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/health", headers={"Origin": "http://example.com"})
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "http://example.com"
+    assert resp.headers["access-control-allow-credentials"] == "true"


### PR DESCRIPTION
## Summary
- enable CORS via `cors_origins` option in `create_app`/`start_server`
- document new environment variable `MOOGLA_CORS_ORIGINS`
- add CORS middleware when origins are provided
- test that CORS headers are returned when enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21a508848332af3ab34dd00f9598