### PR TITLE
Enhance plugin add CLI settings

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,6 +27,7 @@ a YAML or JSON file (by default `~/.cache/moogla/plugins.yaml`).
 
 ```bash
 moogla plugin add my_plugin
+moogla plugin add my_plugin --set greeting=hello --set retries=3
 moogla plugin list
 moogla plugin remove my_plugin
 ```
@@ -44,7 +45,12 @@ moogla plugin add my_plugin
 
 Additional options for a plugin can be stored alongside its name in the
 configuration file. When a plugin defines a `setup(settings: dict)` function,
-those settings are passed to it on load.
+those settings are passed to it on load. When adding a plugin via the CLI you
+can provide settings with the `--set` option:
+
+```bash
+moogla plugin add my_plugin --set greeting=hello --set retries=3
+```
 
 Example YAML structure:
 

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -30,9 +30,25 @@ def plugin_callback(
 
 
 @plugin_app.command("add")
-def plugin_add(name: str) -> None:
+def plugin_add(
+    name: str,
+    set_option: List[str] = typer.Option(
+        None,
+        "--set",
+        "-s",
+        help="Plugin setting in key=value form",
+        metavar="KEY=VALUE",
+    ),
+) -> None:
     """Add a plugin to the persistent store."""
-    plugins_config.add_plugin(name)
+    settings = {}
+    if set_option:
+        for item in set_option:
+            if "=" not in item:
+                raise typer.BadParameter(f"Invalid setting '{item}'", param_hint="--set")
+            key, value = item.split("=", 1)
+            settings[key] = value
+    plugins_config.add_plugin(name, **settings)
     typer.echo(f"Added {name}")
 
 

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -13,8 +13,22 @@ def test_cli_plugin_management(tmp_path, monkeypatch):
     cfg = tmp_path / "plugins.yaml"
     monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
 
-    result = runner.invoke(app, ["plugin", "add", "tests.dummy_plugin"])
+    result = runner.invoke(
+        app,
+        [
+            "plugin",
+            "add",
+            "tests.dummy_plugin",
+            "--set",
+            "flag=yes",
+            "--set",
+            "number=1",
+        ],
+    )
     assert result.exit_code == 0
+
+    settings = plugins_config.get_plugin_settings("tests.dummy_plugin")
+    assert settings == {"flag": "yes", "number": "1"}
 
     result = runner.invoke(app, ["plugin", "list"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- support adding plugin settings via CLI with repeated `--set key=value`
- document how to use `--set`
- test CLI plugin add with settings

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21a630688332ad36857145352717