### PR TITLE
Add model removal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ List downloaded files with:
 moogla models
 ```
 
+Remove a cached model with:
+
+```bash
+moogla remove model.bin
+```
+
 To use a Hugging Face model ID instead of a file path:
 
 ```bash

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,3 +24,5 @@ moogla --help
 By default `moogla pull` stores downloaded models in `~/.cache/moogla/models`.
 Set `MOOGLA_MODEL_DIR` to choose a different location. All commands that use
 local models will look for files in this directory.
+
+List cached models with `moogla models` and remove one using `moogla remove <name>`.

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -230,5 +230,23 @@ def models() -> None:
             typer.echo(n)
 
 
+@app.command()
+def remove(model: str) -> None:
+    """Delete a model file from the local cache."""
+    settings = Settings()
+    path = settings.model_dir / model
+
+    if not path.exists():
+        typer.echo(f"Model not found: {model}")
+        raise typer.Exit(code=1)
+
+    if not typer.confirm(f"Delete {path}?"):
+        typer.echo("Aborted")
+        raise typer.Exit(code=1)
+
+    path.unlink()
+    typer.echo(f"Deleted {path.name}")
+
+
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,3 +141,16 @@ def test_models_lists_files(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "a.bin" in result.output
     assert "b.gguf" in result.output
+
+
+def test_remove_model(tmp_path, monkeypatch):
+    models_dir = tmp_path / ".cache" / "moogla" / "models"
+    models_dir.mkdir(parents=True)
+    path = models_dir / "a.bin"
+    path.write_text("hi")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["remove", "a.bin"], input="y\n")
+    assert result.exit_code == 0
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- add new `remove` CLI command for deleting cached models
- document the command
- test model removal functionality

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21a7adc483329be90c8850c8b5da