### PR TITLE
Add plugin teardown hooks

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -72,3 +72,15 @@ def preprocess(text: str) -> str:
 Settings are automatically provided when running `moogla serve` or creating the
 application programmatically.
 
+
+## Teardown Hooks
+
+Plugins can also clean up resources when the application shuts down. Define a
+`teardown` or `teardown_async` function in the plugin module and it will be
+called during application shutdown.
+
+```python
+# my_plugin.py
+async def teardown_async() -> None:
+    await connection.close()
+```

--- a/tests/teardown_plugin.py
+++ b/tests/teardown_plugin.py
@@ -1,0 +1,8 @@
+import asyncio
+
+called = 0
+
+async def teardown_async() -> None:
+    await asyncio.sleep(0)
+    global called
+    called += 1

--- a/tests/test_teardown_plugin.py
+++ b/tests/test_teardown_plugin.py
@@ -1,0 +1,35 @@
+import importlib
+import os
+
+import httpx
+import pytest
+
+from moogla import server
+from moogla.server import create_app
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+
+class DummyExecutor:
+    async def acomplete(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None) -> str:
+        return prompt[::-1]
+
+    async def astream(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None):
+        text = prompt[::-1]
+        for i in range(0, len(text), 2):
+            yield text[i : i + 2]
+
+
+@pytest.mark.asyncio
+async def test_teardown_async_called(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    plugin = importlib.import_module("tests.teardown_plugin")
+    plugin.called = 0
+    app = create_app(["tests.teardown_plugin"])
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/v1/completions", json={"prompt": "abc"})
+    assert resp.status_code == 200
+    assert plugin.called == 1


### PR DESCRIPTION
## Summary
- support optional `teardown`/`teardown_async` plugin hooks
- call teardown hooks when FastAPI app shuts down
- document teardown hooks in plugin docs
- test teardown hooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21a903c48332ae8a8c80ba886920