### PR TITLE
Fix import order in executor

### DIFF
--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for executing prompts against LLM providers."""
+
+from __future__ import annotations
 
 import asyncio
 import threading


### PR DESCRIPTION
## Summary
- reorder imports so module docstring is on line 1
- keep imports directly after docstring

## Testing
- `ruff check src/moogla/executor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c319d9f3883328db1af71d7657602