### PR TITLE
Require JWT secret with API key

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,7 +13,9 @@ authentication. After registration, send the returned token in an
 
 Tokens are signed with `MOOGLA_JWT_SECRET`. If this variable is not set the
 server generates a random value on startup, meaning issued tokens become
-invalid after a restart. Specify a persistent secret in production.
+invalid after a restart. **Always set a persistent secret in production**,
+especially when `MOOGLA_API_KEY` is configured, otherwise the server will
+refuse to start.
 
 `MOOGLA_TOKEN_EXP_MINUTES` configures the token lifetime in minutes. The
 default is `30`.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
+import asyncio
+
 import httpx
 import pytest
-import asyncio
 
 from moogla import server
 from moogla.server import create_app
@@ -40,7 +41,7 @@ class DummyExecutor:
 @pytest.mark.asyncio
 async def test_authenticated_access(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
-    app = create_app(server_api_key="secret")
+    app = create_app(server_api_key="secret", jwt_secret="jwt")
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -55,7 +56,7 @@ async def test_authenticated_access(monkeypatch):
 @pytest.mark.asyncio
 async def test_missing_api_key(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
-    app = create_app(server_api_key="secret")
+    app = create_app(server_api_key="secret", jwt_secret="jwt")
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -67,7 +68,9 @@ async def test_missing_api_key(monkeypatch):
 async def test_jwt_auth(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     db = tmp_path / "db.db"
-    app = create_app(server_api_key="secret", db_url=f"sqlite:///{db}")
+    app = create_app(
+        server_api_key="secret", db_url=f"sqlite:///{db}", jwt_secret="jwt"
+    )
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -87,7 +90,9 @@ async def test_jwt_auth(monkeypatch, tmp_path):
 async def test_user_endpoints(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     db = tmp_path / "db.db"
-    app = create_app(server_api_key="secret", db_url=f"sqlite:///{db}")
+    app = create_app(
+        server_api_key="secret", db_url=f"sqlite:///{db}", jwt_secret="jwt"
+    )
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -115,7 +120,12 @@ async def test_user_endpoints(monkeypatch, tmp_path):
 async def test_token_expiration(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     db = tmp_path / "db.db"
-    app = create_app(server_api_key="secret", db_url=f"sqlite:///{db}", token_exp_minutes=0)
+    app = create_app(
+        server_api_key="secret",
+        db_url=f"sqlite:///{db}",
+        token_exp_minutes=0,
+        jwt_secret="jwt",
+    )
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:

--- a/tests/test_jwt_secret.py
+++ b/tests/test_jwt_secret.py
@@ -1,0 +1,23 @@
+import pytest
+
+import moogla.server as server
+from moogla.server import create_app
+
+
+class DummyExecutor:
+    def complete(self, *a, **kw):
+        return ""
+
+    async def acomplete(self, *a, **kw):
+        return ""
+
+    async def astream(self, *a, **kw):
+        yield ""
+
+
+@pytest.mark.asyncio
+async def test_missing_jwt_secret(monkeypatch):
+    monkeypatch.delenv("MOOGLA_JWT_SECRET", raising=False)
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    with pytest.raises(RuntimeError):
+        create_app(server_api_key="secret")


### PR DESCRIPTION
## Summary
- document the need for `MOOGLA_JWT_SECRET`
- fail `create_app` when API key is used without a secret
- adapt auth tests to pass a persistent secret
- add regression test for missing secret

## Testing
- `pre-commit run --files docs/authentication.md src/moogla/server.py tests/test_auth.py tests/test_jwt_secret.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c319f96a48332a58f05358df73334