### PR TITLE
Add http download mock test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,39 @@ def test_pull_downloads_to_custom_dir():
             assert (Path(target_dir) / "dummy.txt").exists()
 
 
+def test_pull_http_download(monkeypatch, tmp_path):
+    import contextlib
+    import httpx
+
+    data = b"hello"
+
+    def fake_stream(method, url, *a, **kw):
+        @contextlib.contextmanager
+        def cm():
+            class FakeResp:
+                headers = {"content-length": str(len(data))}
+
+                def raise_for_status(self):
+                    pass
+
+                def iter_bytes(self):
+                    yield from [data[:2], data[2:]]
+
+            yield FakeResp()
+
+        return cm()
+
+    monkeypatch.setattr(httpx, "stream", fake_stream)
+
+    result = runner.invoke(
+        app, ["pull", "http://example.com/x.bin", "--directory", str(tmp_path)]
+    )
+    assert result.exit_code == 0
+    out_file = tmp_path / "x.bin"
+    assert out_file.exists()
+    assert out_file.read_bytes() == data
+
+
 def test_pull_http_error(monkeypatch, tmp_path):
     import contextlib
 


### PR DESCRIPTION
## Summary
- mock `httpx.stream` to emulate a real file download
- check that pulling via URL saves the file and exits with status code 0

## Testing
- `pytest tests/test_cli.py::test_pull_http_download -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c31a26bac8332beb0b0985b2bc62e