### PR TITLE
Use multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
-FROM python:3.11-slim
-WORKDIR /app
-COPY . .
+FROM python:3.11-slim AS builder
+WORKDIR /build
+
+# Install runtime dependencies
+COPY pyproject.toml README.md ./
+COPY src ./src
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir .
+    pip install --no-cache-dir --prefix=/install .
+
+FROM python:3.11-slim AS runtime
+WORKDIR /app
+COPY --from=builder /install /usr/local
 EXPOSE 11434
 CMD ["moogla", "serve"]

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Build the image and start the server:
 docker build -t moogla .
 docker run -p 11434:11434 moogla
 ```
+The Dockerfile now uses multi-stage builds so the final image only contains the
+installed package and its runtime dependencies.
 
 You can also use `docker-compose` to start the service with a few sensible
 defaults. The compose file mounts a local `./models` directory into `/models`


### PR DESCRIPTION
## Summary
- add builder stage and move only installed files to runtime image
- note use of multi-stage builds in README

## Testing
- `pre-commit run --files Dockerfile README.md docker-compose.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed5227294833280c8bde023e89ee0