### PR TITLE
Add log level configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ used for tracking request counts (default `redis://localhost:6379`). These value
 can also be passed to `create_app` or `moogla serve`.
 Set `MOOGLA_CORS_ORIGINS` to send CORS headers for a comma-separated list of
 allowed origins.
+Set `MOOGLA_LOG_LEVEL` to control application logging (default `INFO`).
 
 The API also exposes `/register` and `/login` endpoints for JWT-based
 authentication. POST a username and password to `/register` to persist a user

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -33,5 +33,6 @@ class Settings(BaseSettings):
     cors_origins: Optional[str] = Field(
         None, validation_alias="MOOGLA_CORS_ORIGINS"
     )
+    log_level: str = Field("INFO", validation_alias="MOOGLA_LOG_LEVEL")
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -42,9 +42,18 @@ def create_app(
     jwt_secret: Optional[str] = None,
     token_exp_minutes: Optional[int] = None,
     cors_origins: Optional[str] = None,
+    log_level: Optional[str] = None,
 ) -> FastAPI:
-    """Build the FastAPI application."""
+    """Build the FastAPI application.
+
+    Parameters
+    ----------
+    log_level: Optional logging level passed to :func:`logging.basicConfig`.
+    """
     settings = settings or Settings()
+    log_level = log_level or settings.log_level
+    logging.basicConfig(level=log_level)
+
     model = model or settings.model
     model_dir = settings.model_dir
     api_key = api_key or settings.openai_api_key


### PR DESCRIPTION
## Summary
- add log level field to `Settings`
- allow `create_app` to set the log level
- document `MOOGLA_LOG_LEVEL`

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed52280048332bb663d56bbdcfa8e