### PR TITLE
Add optional metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ modular, observable and developer friendly.
 - FastAPI server exposing OpenAI compatible endpoints
 - Optional API authentication via API key or JWT
 - Redis‑backed rate limiting
+- Optional Prometheus metrics endpoint
 - Built‑in dark‑mode web UI with file uploads and quick hints
 - Command to download models for offline use
 - Command to list available local models

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,15 @@
+# Metrics
+
+Set `MOOGLA_METRICS=1` to expose a Prometheus compatible `/metrics` endpoint.
+The server records request counts and latency for each route. Example:
+
+```bash
+export MOOGLA_METRICS=1
+moogla serve
+```
+
+Query metrics with:
+
+```bash
+curl http://localhost:11434/metrics
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,4 +9,5 @@ nav:
   - Local Models: local_models.md
   - Plugin Development: plugins.md
   - Authentication: authentication.md
+  - Metrics: metrics.md
   - Web UI: web_ui.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "python-jose>=3.3",
     "pyyaml>=6.0",
     "pydantic-settings>=2.0",
+    "prometheus_client>=0.19",
 ]
 
 [project.scripts]

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -30,8 +30,7 @@ class Settings(BaseSettings):
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
         validation_alias="MOOGLA_MODEL_DIR",
     )
-    cors_origins: Optional[str] = Field(
-        None, validation_alias="MOOGLA_CORS_ORIGINS"
-    )
+    cors_origins: Optional[str] = Field(None, validation_alias="MOOGLA_CORS_ORIGINS")
+    metrics: bool = Field(False, validation_alias="MOOGLA_METRICS")
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,38 @@
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import moogla.server as server
+from moogla.server import create_app
+
+
+class DummyExecutor:
+    def complete(self, *a, **kw):
+        return ""
+
+    async def acomplete(self, *a, **kw):
+        return ""
+
+    async def astream(self, *a, **kw):
+        yield ""
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(enable_metrics=True)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get("/health")
+        resp = await client.get("/metrics")
+    assert resp.status_code == 200
+    assert "http_requests_total" in resp.text
+
+
+def test_metrics_disabled(monkeypatch):
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    app = create_app(enable_metrics=False)
+    client = TestClient(app)
+    resp = client.get("/metrics")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add optional prometheus-based metrics in server
- expose `/metrics` route when `MOOGLA_METRICS` is set
- document metrics configuration
- include unit tests
- update dependencies

## Testing
- `pre-commit run --files README.md mkdocs.yml pyproject.toml src/moogla/config.py src/moogla/server.py docs/metrics.md tests/test_metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed52444648332aa1c1dd1bac0ac37