### PR TITLE
Add CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
-          pip install pytest-asyncio
+          pip install pytest-asyncio coverage
       - name: Run pre-commit
         run: pre-commit run --all-files
       - name: Run tests
-        run: pytest
+        run: coverage run -m pytest
+      - name: Generate coverage report
+        run: coverage xml -o coverage.xml
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
 
   publish:
     if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Moogla
 
+[![codecov](https://codecov.io/gh/example/Moogla/branch/main/graph/badge.svg)](https://codecov.io/gh/example/Moogla)
+
 Moogla is a self‑hosted LLM runtime and orchestration framework for power users.
 It combines local‑first execution with the flexibility required for
 production‑grade workflows.  The repository starts with a minimal project layout


### PR DESCRIPTION
## Summary
- install coverage during CI
- run tests under coverage
- upload coverage data to Codecov
- display a Codecov badge in the README

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml`
- `coverage run -m pytest`
- `coverage xml -o coverage.xml`
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_e_685ed526696c8332b14ddb16bb0384ec