### PR TITLE
Add plugin clear command

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -45,7 +45,9 @@ def plugin_add(
     if set_option:
         for item in set_option:
             if "=" not in item:
-                raise typer.BadParameter(f"Invalid setting '{item}'", param_hint="--set")
+                raise typer.BadParameter(
+                    f"Invalid setting '{item}'", param_hint="--set"
+                )
             key, value = item.split("=", 1)
             settings[key] = value
     plugins_config.add_plugin(name, **settings)
@@ -79,6 +81,13 @@ def plugin_show(name: str) -> None:
     else:
         for k, v in settings.items():
             typer.echo(f"{k}={v}")
+
+
+@plugin_app.command("clear")
+def plugin_clear() -> None:
+    """Remove all plugins from the store."""
+    plugins_config.clear_plugins()
+    typer.echo("Cleared plugin configuration")
 
 
 @app.command()

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -84,6 +84,12 @@ def remove_plugin(name: str) -> None:
         data["settings"].pop(name, None)
     _save(data)
 
+
+def clear_plugins() -> None:
+    """Remove all plugins and settings from the config file."""
+    _save({})
+
+
 def get_plugin_settings(name: str) -> Dict[str, Any]:
     """Return stored settings for the given plugin."""
     data = _load()
@@ -102,4 +108,3 @@ def get_all_plugin_settings() -> Dict[str, Dict[str, Any]]:
     if isinstance(settings, dict):
         return {k: v for k, v in settings.items() if isinstance(v, dict)}
     return {}
-

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -1,7 +1,8 @@
+from pathlib import Path
+
+import pytest
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
-from pathlib import Path
-import pytest
 
 from moogla import plugins_config, server
 from moogla.cli import app
@@ -120,3 +121,12 @@ def test_permission_error_raises_runtime_error(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError):
         plugins_config.get_plugins()
 
+
+def test_cli_plugin_clear(tmp_path, monkeypatch):
+    cfg = tmp_path / "plugins.yaml"
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
+    plugins_config.add_plugin("tests.dummy_plugin")
+    result = runner.invoke(app, ["plugin", "clear"])
+    assert result.exit_code == 0
+    assert "Cleared" in result.output
+    assert plugins_config.get_plugins() == []


### PR DESCRIPTION
## Summary
- add `clear_plugins` utility
- add `plugin clear` command to CLI
- test clearing plugins

## Testing
- `pre-commit run --files src/moogla/cli.py src/moogla/plugins_config.py tests/test_plugin_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623f0b19d08332b0c93838a9a983bc