### PR TITLE
Improve security defaults

### DIFF
--- a/src/moogla/__init__.py
+++ b/src/moogla/__init__.py
@@ -1,6 +1,7 @@
 """Moogla core package."""
 
 from importlib.metadata import version
+
 from .executor import LLMExecutor
 
 __all__ = ["__version__", "LLMExecutor"]

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -5,10 +5,13 @@ from urllib.parse import urlparse
 
 import httpx
 import typer
+from dotenv import load_dotenv
 
 from . import plugins_config
 from .config import Settings
 from .server import start_server
+
+load_dotenv()
 
 app = typer.Typer(help="Moogla command line interface")
 plugin_app = typer.Typer(help="Manage plugins")
@@ -92,7 +95,7 @@ def plugin_clear() -> None:
 
 @app.command()
 def serve(
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 11434,
     plugin: List[str] = typer.Option(
         None, "--plugin", "-p", help="Plugin module to load", show_default=False

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -30,9 +30,7 @@ class Settings(BaseSettings):
         default_factory=lambda: Path.home() / ".cache" / "moogla" / "models",
         validation_alias="MOOGLA_MODEL_DIR",
     )
-    cors_origins: Optional[str] = Field(
-        None, validation_alias="MOOGLA_CORS_ORIGINS"
-    )
+    cors_origins: Optional[str] = Field(None, validation_alias="MOOGLA_CORS_ORIGINS")
     log_level: str = Field("INFO", validation_alias="MOOGLA_LOG_LEVEL")
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -186,9 +186,7 @@ class LLMExecutor:
             return
 
         if self.async_llama:
-            result = await self.async_llama(
-                prompt, max_tokens=max_tokens, stream=True
-            )
+            result = await self.async_llama(prompt, max_tokens=max_tokens, stream=True)
             async for chunk in result:
                 text = chunk.get("choices", [{}])[0].get("text")
                 if text:
@@ -238,9 +236,7 @@ class LLMExecutor:
             return response.choices[0].message.content
 
         if self.async_llama:
-            result = await self.async_llama(
-                prompt, max_tokens=max_tokens
-            )
+            result = await self.async_llama(prompt, max_tokens=max_tokens)
             return result["choices"][0]["text"]
 
         # Some backends expose only synchronous APIs so local inference can

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -27,9 +27,7 @@ class Plugin:
         self.postprocess_async: Optional[Callable[[str], str]] = getattr(
             module, "postprocess_async", None
         )
-        self.teardown: Optional[Callable[[], None]] = getattr(
-            module, "teardown", None
-        )
+        self.teardown: Optional[Callable[[], None]] = getattr(module, "teardown", None)
         self.teardown_async: Optional[Callable[[], None]] = getattr(
             module, "teardown_async", None
         )

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -204,7 +204,6 @@ def create_app(
                 return FileResponse(path, filename=name)
         raise HTTPException(status_code=404, detail="Package not found")
 
-
     class Credentials(BaseModel):
         username: str
         password: str
@@ -236,7 +235,7 @@ def create_app(
                 raise HTTPException(status_code=401, detail="Invalid credentials")
         payload = {
             "sub": str(user.id),
-            "exp": datetime.utcnow() + timedelta(minutes=token_exp_minutes),
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=token_exp_minutes),
         }
         token = jwt.encode(payload, secret_key, algorithm=algorithm)
         return {"access_token": token, "token_type": "bearer"}
@@ -410,7 +409,7 @@ def create_app(
 
 
 def start_server(
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 11434,
     plugin_names: Optional[List[str]] = None,
     model: Optional[str] = None,

--- a/tests/async_setup_plugin.py
+++ b/tests/async_setup_plugin.py
@@ -2,6 +2,7 @@ import asyncio
 
 configured = {}
 
+
 async def setup_async(settings: dict) -> None:
     await asyncio.sleep(0)
     configured.clear()

--- a/tests/setup_plugin.py
+++ b/tests/setup_plugin.py
@@ -9,4 +9,3 @@ def setup(settings: dict) -> None:
 def postprocess(text: str) -> str:
     suffix = configured.get("suffix", "")
     return f"{text}{suffix}"
-

--- a/tests/teardown_plugin.py
+++ b/tests/teardown_plugin.py
@@ -2,6 +2,7 @@ import asyncio
 
 called = 0
 
+
 async def teardown_async() -> None:
     await asyncio.sleep(0)
     global called

--- a/tests/test_async_llama.py
+++ b/tests/test_async_llama.py
@@ -1,9 +1,11 @@
 import asyncio
 import sys
 import types
+
 import pytest
 
 from moogla.executor import LLMExecutor
+
 
 class DummyAsyncLlama:
     def __init__(self, model_path: str) -> None:
@@ -11,15 +13,20 @@ class DummyAsyncLlama:
 
     async def __call__(self, prompt: str, max_tokens: int = 16, stream: bool = False):
         if stream:
+
             async def gen():
                 for ch in prompt[::-1]:
                     yield {"choices": [{"text": ch}]}
+
             return gen()
         return {"choices": [{"text": prompt[::-1]}]}
 
+
 @pytest.mark.asyncio
 async def test_async_llama_usage(monkeypatch):
-    dummy_module = types.SimpleNamespace(AsyncLlama=DummyAsyncLlama, Llama=DummyAsyncLlama)
+    dummy_module = types.SimpleNamespace(
+        AsyncLlama=DummyAsyncLlama, Llama=DummyAsyncLlama
+    )
     monkeypatch.setitem(sys.modules, "llama_cpp", dummy_module)
 
     called = False

--- a/tests/test_async_setup_plugin.py
+++ b/tests/test_async_setup_plugin.py
@@ -1,6 +1,6 @@
+import asyncio
 import importlib
 import os
-import asyncio
 
 import httpx
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,11 @@
 import types
 
-import openai
 import httpx
+import openai
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
-from moogla import server, plugins_config
+from moogla import plugins_config, server
 from moogla.cli import app
 
 runner = CliRunner()
@@ -101,6 +101,7 @@ def test_pull_downloads_to_custom_dir():
 
 def test_pull_http_download(monkeypatch, tmp_path):
     import contextlib
+
     import httpx
 
     data = b"hello"
@@ -207,10 +208,22 @@ def test_reload_plugins_command(monkeypatch, tmp_path):
     plugins_config.add_plugin("tests.dummy_plugin")
 
     class DummyExecutor:
-        async def acomplete(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None) -> str:
+        async def acomplete(
+            self,
+            prompt: str,
+            max_tokens: int | None = None,
+            temperature: float | None = None,
+            top_p: float | None = None,
+        ) -> str:
             return prompt[::-1]
 
-        async def astream(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None):
+        async def astream(
+            self,
+            prompt: str,
+            max_tokens: int | None = None,
+            temperature: float | None = None,
+            top_p: float | None = None,
+        ):
             text = prompt[::-1]
             for i in range(0, len(text), 2):
                 yield text[i : i + 2]
@@ -237,4 +250,3 @@ def test_reload_plugins_command(monkeypatch, tmp_path):
     assert result.exit_code == 0
     resp = client.post("/v1/completions", json={"prompt": "abc"})
     assert resp.json()["choices"][0]["text"] == "cba!!"
-

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -9,7 +9,9 @@ class DummyExecutor:
     def complete(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
         return prompt
 
-    async def acomplete(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
+    async def acomplete(
+        self, prompt: str, max_tokens=None, temperature=None, top_p=None
+    ):
         return prompt
 
     async def astream(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
@@ -20,7 +22,9 @@ class DummyExecutor:
 async def test_cors_headers(monkeypatch):
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app = create_app(cors_origins="http://example.com")
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.get("/health", headers={"Origin": "http://example.com"})
     assert resp.status_code == 200
     assert resp.headers["access-control-allow-origin"] == "http://example.com"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
-from moogla import server, plugins_config
+from moogla import plugins_config, server
 from moogla.server import create_app
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
@@ -219,4 +219,3 @@ async def test_reload_plugins_endpoint(monkeypatch, tmp_path):
 
         resp = await client.post("/v1/completions", json={"prompt": "x"})
         assert resp.json()["choices"][0]["text"] == "x??"
-

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,8 +1,8 @@
+import asyncio
 import types
 
 import openai
 import pytest
-import asyncio
 
 from moogla.executor import LLMExecutor
 

--- a/tests/test_teardown_plugin.py
+++ b/tests/test_teardown_plugin.py
@@ -11,10 +11,22 @@ os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 
 class DummyExecutor:
-    async def acomplete(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None) -> str:
+    async def acomplete(
+        self,
+        prompt: str,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ) -> str:
         return prompt[::-1]
 
-    async def astream(self, prompt: str, max_tokens: int | None = None, temperature: float | None = None, top_p: float | None = None):
+    async def astream(
+        self,
+        prompt: str,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ):
         text = prompt[::-1]
         for i in range(0, len(text), 2):
             yield text[i : i + 2]


### PR DESCRIPTION
## Summary
- run code formatters across the repo
- bind the server to localhost by default
- load environment variables from a `.env` file
- use timezone aware JWT expiration

## Testing
- `pre-commit run --files src/moogla/cli.py src/moogla/server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864308529688332b13bdbbdd8295b47