### PR TITLE
Add confirmation bypass for model removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Remove a cached model with:
 ```bash
 moogla remove model.bin
 ```
+Use `-y` to skip the confirmation prompt:
+
+```bash
+moogla remove model.bin -y
+```
 
 To use a Hugging Face model ID instead of a file path:
 

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -294,7 +294,15 @@ def reload_plugins(
 
 
 @app.command()
-def remove(model: str) -> None:
+def remove(
+    model: str,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Delete without confirmation",
+    ),
+) -> None:
     """Delete a model file from the local cache."""
     settings = Settings()
     path = settings.model_dir / model
@@ -303,7 +311,7 @@ def remove(model: str) -> None:
         typer.echo(f"Model not found: {model}")
         raise typer.Exit(code=1)
 
-    if not typer.confirm(f"Delete {path}?"):
+    if not yes and not typer.confirm(f"Delete {path}?"):
         typer.echo("Aborted")
         raise typer.Exit(code=1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,30 @@ def test_remove_model(tmp_path, monkeypatch):
     assert not path.exists()
 
 
+def test_remove_model_yes_flag(tmp_path, monkeypatch):
+    models_dir = tmp_path / ".cache" / "moogla" / "models"
+    models_dir.mkdir(parents=True)
+    path = models_dir / "b.bin"
+    path.write_text("hi")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["remove", "b.bin", "--yes"])
+    assert result.exit_code == 0
+    assert not path.exists()
+
+
+def test_remove_model_missing(tmp_path, monkeypatch):
+    models_dir = tmp_path / ".cache" / "moogla" / "models"
+    models_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["remove", "c.bin", "--yes"])
+    assert result.exit_code == 1
+    assert "Model not found" in result.output
+
+
 def test_plugin_show_command(tmp_path, monkeypatch):
     cfg = tmp_path / "plugins.yaml"
     monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))


### PR DESCRIPTION
## Summary
- add `--yes` flag to `moogla remove` command
- document removal flag in README
- test removing models with the new flag and missing files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643a01cd04833294add850aee28e6c