### PR TITLE
Improve plugin configuration management

### DIFF
--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -1,3 +1,7 @@
+"""Utility helpers for loading and saving plugin configuration."""
+
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path
@@ -5,108 +9,127 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-PLUGIN_FILE_PATH: Optional[Path] = None
+
+class PluginStore:
+    """Persist and retrieve plugin configuration from disk."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = path or Path.home() / ".cache" / "moogla" / "plugins.yaml"
+
+    def set_path(self, path: Optional[str]) -> None:
+        self.path = Path(path) if path else Path.home() / ".cache" / "moogla" / "plugins.yaml"
+
+    def _resolve_path(self) -> Path:
+        env = os.getenv("MOOGLA_PLUGIN_FILE")
+        if env:
+            return Path(env)
+        return self.path
+
+    def load(self) -> Dict[str, Any]:
+        path = self._resolve_path()
+        if not path.exists():
+            return {}
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                if path.suffix in {".yaml", ".yml"}:
+                    return yaml.safe_load(f) or {}
+                return json.load(f)
+        except (OSError, json.JSONDecodeError, yaml.YAMLError) as e:  # pragma: no cover - file errors
+            raise RuntimeError(f"Failed to load plugin config: {e}") from e
+
+    def save(self, data: Dict[str, Any]) -> None:
+        path = self._resolve_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                if path.suffix in {".yaml", ".yml"}:
+                    yaml.safe_dump(data, f)
+                else:
+                    json.dump(data, f, indent=2)
+        except OSError as e:  # pragma: no cover - filesystem errors
+            raise RuntimeError(f"Failed to save plugin config: {e}") from e
+
+    def get_plugins(self) -> List[str]:
+        data = self.load()
+        plugins = data.get("plugins")
+        if isinstance(plugins, list):
+            return plugins
+        if isinstance(data, list):
+            return data
+        return []
+
+    def add_plugin(self, name: str, **settings: Any) -> None:
+        data = self.load()
+        plugins = data.get("plugins")
+        if plugins is None:
+            if isinstance(data, list):
+                plugins = data
+            else:
+                plugins = []
+            data["plugins"] = plugins
+        if name not in plugins:
+            plugins.append(name)
+        if settings:
+            data.setdefault("settings", {}).setdefault(name, {}).update(settings)
+        self.save(data)
+
+    def remove_plugin(self, name: str) -> None:
+        data = self.load()
+        plugins = data.get("plugins")
+        if isinstance(plugins, list) and name in plugins:
+            plugins.remove(name)
+        if isinstance(data.get("settings"), dict):
+            data["settings"].pop(name, None)
+        self.save(data)
+
+    def clear_plugins(self) -> None:
+        self.save({})
+
+    def get_plugin_settings(self, name: str) -> Dict[str, Any]:
+        data = self.load()
+        settings = data.get("settings")
+        if isinstance(settings, dict):
+            value = settings.get(name)
+            if isinstance(value, dict):
+                return value
+        return {}
+
+    def get_all_plugin_settings(self) -> Dict[str, Dict[str, Any]]:
+        data = self.load()
+        settings = data.get("settings")
+        if isinstance(settings, dict):
+            return {k: v for k, v in settings.items() if isinstance(v, dict)}
+        return {}
+
+
+_default = PluginStore()
 
 
 def set_plugin_file(path: Optional[str]) -> None:
     """Override the location of the plugin configuration file."""
-    global PLUGIN_FILE_PATH
-    PLUGIN_FILE_PATH = Path(path) if path else None
-
-
-def _get_path() -> Path:
-    env = os.getenv("MOOGLA_PLUGIN_FILE")
-    if env:
-        return Path(env)
-    if PLUGIN_FILE_PATH is not None:
-        return PLUGIN_FILE_PATH
-    return Path.home() / ".cache" / "moogla" / "plugins.yaml"
-
-
-def _load() -> Dict[str, Any]:
-    """Return the current plugin configuration as a dictionary."""
-    path = _get_path()
-    if not path.exists():
-        return {}
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            if path.suffix in {".yaml", ".yml"}:
-                return yaml.safe_load(f) or {}
-            return json.load(f)
-    except (OSError, json.JSONDecodeError, yaml.YAMLError) as e:
-        raise RuntimeError(f"Failed to load plugin config: {e}") from e
-
-
-def _save(data: Dict[str, Any]) -> None:
-    """Persist the given plugin configuration to disk."""
-    path = _get_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with open(path, "w", encoding="utf-8") as f:
-            if path.suffix in {".yaml", ".yml"}:
-                yaml.safe_dump(data, f)
-            else:
-                json.dump(data, f, indent=2)
-    except OSError as e:
-        raise RuntimeError(f"Failed to save plugin config: {e}") from e
+    _default.set_path(path)
 
 
 def get_plugins() -> List[str]:
-    data = _load()
-    plugins = data.get("plugins")
-    if isinstance(plugins, list):
-        return plugins
-    if isinstance(data, list):
-        return data
-    return []
+    return _default.get_plugins()
 
 
 def add_plugin(name: str, **settings: Any) -> None:
-    data = _load()
-    plugins = data.get("plugins")
-    if plugins is None:
-        if isinstance(data, list):
-            plugins = data
-        else:
-            plugins = []
-        data["plugins"] = plugins
-    if name not in plugins:
-        plugins.append(name)
-    if settings:
-        data.setdefault("settings", {}).setdefault(name, {}).update(settings)
-    _save(data)
+    _default.add_plugin(name, **settings)
 
 
 def remove_plugin(name: str) -> None:
-    data = _load()
-    plugins = data.get("plugins")
-    if isinstance(plugins, list) and name in plugins:
-        plugins.remove(name)
-    if isinstance(data.get("settings"), dict):
-        data["settings"].pop(name, None)
-    _save(data)
+    _default.remove_plugin(name)
 
 
 def clear_plugins() -> None:
-    """Remove all plugins and settings from the config file."""
-    _save({})
+    _default.clear_plugins()
 
 
 def get_plugin_settings(name: str) -> Dict[str, Any]:
-    """Return stored settings for the given plugin."""
-    data = _load()
-    settings = data.get("settings")
-    if isinstance(settings, dict):
-        value = settings.get(name)
-        if isinstance(value, dict):
-            return value
-    return {}
+    return _default.get_plugin_settings(name)
 
 
 def get_all_plugin_settings() -> Dict[str, Dict[str, Any]]:
-    """Return stored settings for all plugins."""
-    data = _load()
-    settings = data.get("settings")
-    if isinstance(settings, dict):
-        return {k: v for k, v in settings.items() if isinstance(v, dict)}
-    return {}
+    return _default.get_all_plugin_settings()
+


### PR DESCRIPTION
## Summary
- refactor `plugins_config` into a `PluginStore` class
- keep environment-based path resolution
- update helper functions to use the new store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643f76c5788332a1446b4c337c6205