### PR TITLE
Add executor cleanup and context manager support

### DIFF
--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -139,6 +139,7 @@ def create_app(
         finally:
             if rate_limit:
                 await FastAPILimiter.close()
+            await executor.aclose()
             for plugin in plugins:
                 try:
                     await plugin.run_teardown()

--- a/tests/test_async_plugin.py
+++ b/tests/test_async_plugin.py
@@ -39,6 +39,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_async_plugin(monkeypatch):

--- a/tests/test_async_setup_plugin.py
+++ b/tests/test_async_setup_plugin.py
@@ -42,6 +42,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 def test_async_setup_called(tmp_path, monkeypatch):
     cfg = tmp_path / "plugins.yaml"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -37,6 +37,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_authenticated_access(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,9 @@ def test_serve_with_plugin(monkeypatch):
             for i in range(0, len(text), 2):
                 yield text[i : i + 2]
 
+        async def aclose(self):
+            pass
+
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
 
     result = runner.invoke(app, ["serve", "--plugin", "tests.dummy_plugin"])
@@ -251,6 +254,9 @@ def test_reload_plugins_command(monkeypatch, tmp_path):
             text = prompt[::-1]
             for i in range(0, len(text), 2):
                 yield text[i : i + 2]
+
+        async def aclose(self):
+            pass
 
     monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
     app_instance = server.create_app()

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -17,6 +17,9 @@ class DummyExecutor:
     async def astream(self, prompt: str, max_tokens=None, temperature=None, top_p=None):
         yield prompt
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_cors_headers(monkeypatch):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -60,6 +60,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_chat_completion(monkeypatch):

--- a/tests/test_error_cases.py
+++ b/tests/test_error_cases.py
@@ -26,6 +26,9 @@ class DummyExecutor:
     ) -> str:
         return prompt[::-1]
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_concurrent_requests(monkeypatch):

--- a/tests/test_executor_close.py
+++ b/tests/test_executor_close.py
@@ -1,0 +1,43 @@
+import types
+
+import openai
+import pytest
+
+from moogla.executor import LLMExecutor
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.closed = False
+        self.chat = types.SimpleNamespace(completions=self)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def create(self, *a, **k):
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(delta=types.SimpleNamespace(content=None))]
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_manager_closes(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(openai, "OpenAI", lambda *a, **k: dummy)
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda *a, **k: dummy)
+
+    async with LLMExecutor(model="gpt-3.5-turbo"):
+        pass
+
+    assert dummy.closed
+
+
+def test_sync_context_manager(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(openai, "OpenAI", lambda *a, **k: dummy)
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda *a, **k: dummy)
+
+    with LLMExecutor(model="gpt-3.5-turbo"):
+        pass
+
+    assert dummy.closed

--- a/tests/test_jwt_secret.py
+++ b/tests/test_jwt_secret.py
@@ -14,6 +14,9 @@ class DummyExecutor:
     async def astream(self, *a, **kw):
         yield ""
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_missing_jwt_secret(monkeypatch):

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -63,6 +63,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 def test_persisted_plugins_loaded(tmp_path, monkeypatch):
     cfg = tmp_path / "plugins.yaml"

--- a/tests/test_plugin_errors.py
+++ b/tests/test_plugin_errors.py
@@ -45,6 +45,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 def test_preprocess_exception_results_in_500(tmp_path, monkeypatch):
     mod = types.ModuleType("error_pre_plugin")

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -43,6 +43,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_rate_limit(monkeypatch):

--- a/tests/test_teardown_plugin.py
+++ b/tests/test_teardown_plugin.py
@@ -31,6 +31,9 @@ class DummyExecutor:
         for i in range(0, len(text), 2):
             yield text[i : i + 2]
 
+    async def aclose(self):
+        pass
+
 
 @pytest.mark.asyncio
 async def test_teardown_async_called(monkeypatch):


### PR DESCRIPTION
## Summary
- add context manager capability to `LLMExecutor`
- close executor resources on app shutdown
- add tests for executor close logic
- update tests to implement `aclose` stubs

## Testing
- `pre-commit run --files src/moogla/executor.py src/moogla/server.py tests/test_executor_close.py tests/test_async_plugin.py tests/test_async_setup_plugin.py tests/test_auth.py tests/test_cli.py tests/test_cors.py tests/test_endpoints.py tests/test_error_cases.py tests/test_jwt_secret.py tests/test_plugin_config.py tests/test_plugin_errors.py tests/test_rate_limit.py tests/test_teardown_plugin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644149d1748332a853c69d148c972a