### PR TITLE
Add CLI options for logging and CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ can also be passed to `create_app` or `moogla serve`.
 Set `MOOGLA_CORS_ORIGINS` to send CORS headers for a comma-separated list of
 allowed origins.
 Set `MOOGLA_LOG_LEVEL` to control application logging (default `INFO`).
+These values can also be provided via the `--cors-origins`, `--log-level` and
+`--token-exp-minutes` options when running `moogla serve`.
 
 The API also exposes `/register` and `/login` endpoints for JWT-based
 authentication. POST a username and password to `/register` to persist a user

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,6 +19,8 @@ refuse to start.
 
 `MOOGLA_TOKEN_EXP_MINUTES` configures the token lifetime in minutes. The
 default is `30`.
+The same value can be set on the command line with `--token-exp-minutes` when
+running `moogla serve`.
 
 User records are kept in an in-memory SQLite database by default. Set
 `MOOGLA_DB_URL` to use a durable database so accounts survive server restarts.

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -156,6 +156,27 @@ def serve(
         envvar="MOOGLA_PLUGIN_FILE",
         show_default=False,
     ),
+    log_level: str = typer.Option(
+        None,
+        "--log-level",
+        help="Logging level for the server",
+        envvar="MOOGLA_LOG_LEVEL",
+        show_default=False,
+    ),
+    cors_origins: str = typer.Option(
+        None,
+        "--cors-origins",
+        help="Comma separated list of allowed CORS origins",
+        envvar="MOOGLA_CORS_ORIGINS",
+        show_default=False,
+    ),
+    token_exp_minutes: int = typer.Option(
+        None,
+        "--token-exp-minutes",
+        help="JWT token expiry in minutes",
+        envvar="MOOGLA_TOKEN_EXP_MINUTES",
+        show_default=False,
+    ),
 ):
     """Start the Moogla HTTP server.
 
@@ -181,6 +202,9 @@ def serve(
         db_url=db_url,
         jwt_secret=jwt_secret,
         plugin_file=plugin_file,
+        log_level=log_level,
+        cors_origins=cors_origins,
+        token_exp_minutes=token_exp_minutes,
     )
 
 

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -424,6 +424,7 @@ def start_server(
     jwt_secret: Optional[str] = None,
     token_exp_minutes: Optional[int] = None,
     cors_origins: Optional[str] = None,
+    log_level: Optional[str] = None,
 ) -> None:
     """Run the HTTP server."""
     app = create_app(
@@ -439,5 +440,6 @@ def start_server(
         jwt_secret=jwt_secret,
         token_exp_minutes=token_exp_minutes,
         cors_origins=cors_origins,
+        log_level=log_level,
     )
     uvicorn.run(app, host=host, port=port)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,34 @@ def test_serve_with_plugin(monkeypatch):
     assert resp.json()["choices"][0]["text"] == "!!CBA!!"
 
 
+def test_serve_option_forwarding(monkeypatch):
+    captured = {}
+
+    def fake_start_server(**kwargs):
+        captured.update(kwargs)
+
+    from moogla import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "start_server", fake_start_server)
+
+    result = runner.invoke(
+        app,
+        [
+            "serve",
+            "--log-level",
+            "DEBUG",
+            "--cors-origins",
+            "http://a.com",
+            "--token-exp-minutes",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured["log_level"] == "DEBUG"
+    assert captured["cors_origins"] == "http://a.com"
+    assert captured["token_exp_minutes"] == 60
+
+
 def test_pull_downloads_to_custom_dir():
     import tempfile
     from pathlib import Path


### PR DESCRIPTION
## Summary
- support more server settings via CLI options
- forward new options through the server entrypoints
- document new flags and env vars
- test that `moogla serve` passes options correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686444873c288332b504c00c04e8a6c3