### PR TITLE
Improve CLI and plugin handling

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -217,6 +217,12 @@ def pull(
         "-d",
         help="Directory to save downloaded models",
     ),
+    timeout: int = typer.Option(
+        30,
+        "--timeout",
+        help="HTTP download timeout in seconds",
+        show_default=True,
+    ),
 ):
     """Download a model into the local cache.
 
@@ -224,6 +230,7 @@ def pull(
     ----------
     model: Identifier, path or URL of the model to fetch.
     directory: Target directory for the downloaded file.
+    timeout: Maximum time in seconds to wait for HTTP downloads.
     """
     settings = Settings()
     dest_dir = directory or settings.model_dir
@@ -240,7 +247,7 @@ def pull(
     if parsed.scheme in {"http", "https", "file"}:
         url = model
         try:
-            with httpx.stream("GET", url) as resp:
+            with httpx.stream("GET", url, timeout=timeout) as resp:
                 resp.raise_for_status()
                 total = int(resp.headers.get("content-length", 0))
                 with (

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -10,6 +10,11 @@ from typing import Optional
 
 import openai
 
+# Default generation parameters
+DEFAULT_MAX_TOKENS = 16
+DEFAULT_TEMPERATURE = 1.0
+DEFAULT_TOP_P = 1.0
+
 
 class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
     """Simple wrapper around the OpenAI client with context manager support."""
@@ -67,11 +72,11 @@ class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
     ) -> str:
         """Return a completion for the given prompt."""
         if max_tokens is None:
-            max_tokens = 16
+            max_tokens = DEFAULT_MAX_TOKENS
         if temperature is None:
-            temperature = 1.0
+            temperature = DEFAULT_TEMPERATURE
         if top_p is None:
-            top_p = 1.0
+            top_p = DEFAULT_TOP_P
         if self.client:
             response = self.client.chat.completions.create(
                 model=self.model,
@@ -99,11 +104,11 @@ class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
     ):
         """Yield completion tokens for the given prompt."""
         if max_tokens is None:
-            max_tokens = 16
+            max_tokens = DEFAULT_MAX_TOKENS
         if temperature is None:
-            temperature = 1.0
+            temperature = DEFAULT_TEMPERATURE
         if top_p is None:
-            top_p = 1.0
+            top_p = DEFAULT_TOP_P
         if self.client:
             response = self.client.chat.completions.create(
                 model=self.model,
@@ -166,11 +171,11 @@ class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
     ):
         """Asynchronously yield completion tokens for the prompt."""
         if max_tokens is None:
-            max_tokens = 16
+            max_tokens = DEFAULT_MAX_TOKENS
         if temperature is None:
-            temperature = 1.0
+            temperature = DEFAULT_TEMPERATURE
         if top_p is None:
-            top_p = 1.0
+            top_p = DEFAULT_TOP_P
         if self.async_client:
             response = await self.async_client.chat.completions.create(
                 model=self.model,
@@ -221,11 +226,11 @@ class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
     ) -> str:
         """Asynchronously return a completion for the given prompt."""
         if max_tokens is None:
-            max_tokens = 16
+            max_tokens = DEFAULT_MAX_TOKENS
         if temperature is None:
-            temperature = 1.0
+            temperature = DEFAULT_TEMPERATURE
         if top_p is None:
-            top_p = 1.0
+            top_p = DEFAULT_TOP_P
         if self.async_client:
             response = await self.async_client.chat.completions.create(
                 model=self.model,

--- a/src/moogla/plugins.py
+++ b/src/moogla/plugins.py
@@ -106,7 +106,9 @@ def load_plugins(
                 logger.error("Failed to setup plugin '%s': %s", name, exc)
                 raise
 
-        plugins.append(Plugin(module))
+        plugin = Plugin(module)
+        plugins.append(plugin)
+        logger.info("Loaded plugin '%s'", name)
 
     plugins.sort(key=lambda p: p.order)
     return plugins

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -13,11 +13,13 @@ import yaml
 class PluginStore:
     """Persist and retrieve plugin configuration from disk."""
 
+    DEFAULT_FILE = Path.home() / ".cache" / "moogla" / "plugins.yaml"
+
     def __init__(self, path: Optional[Path] = None) -> None:
-        self.path = path or Path.home() / ".cache" / "moogla" / "plugins.yaml"
+        self.path = path or self.DEFAULT_FILE
 
     def set_path(self, path: Optional[str]) -> None:
-        self.path = Path(path) if path else Path.home() / ".cache" / "moogla" / "plugins.yaml"
+        self.path = Path(path) if path else self.DEFAULT_FILE
 
     def _resolve_path(self) -> Path:
         env = os.getenv("MOOGLA_PLUGIN_FILE")


### PR DESCRIPTION
## Summary
- add HTTP download timeout option to `moogla pull`
- centralize default generation parameters in `LLMExecutor`
- log plugin loading and simplify default plugin path handling

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686446289b38833286c97c6fc7f17162