### PR TITLE
Improve server shutdown and provide module entrypoint

### DIFF
--- a/src/moogla/__main__.py
+++ b/src/moogla/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -139,7 +139,10 @@ def create_app(
         finally:
             if rate_limit:
                 await FastAPILimiter.close()
+                if redis_conn is not None:
+                    await redis_conn.close()
             await executor.aclose()
+            engine.dispose()
             for plugin in plugins:
                 try:
                     await plugin.run_teardown()

--- a/tests/test_engine_disposal.py
+++ b/tests/test_engine_disposal.py
@@ -1,0 +1,38 @@
+import pytest
+import httpx
+
+from moogla import server
+
+
+class DummyEngine:
+    def __init__(self):
+        self.disposed = False
+
+    def dispose(self):
+        self.disposed = True
+
+
+class DummyExecutor:
+    async def acomplete(self, *a, **kw):
+        return ""
+
+    async def astream(self, *a, **kw):
+        yield ""
+
+    async def aclose(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_engine_disposed(monkeypatch):
+    dummy_engine = DummyEngine()
+    monkeypatch.setattr(server, "LLMExecutor", lambda *a, **kw: DummyExecutor())
+    monkeypatch.setattr(server, "create_engine", lambda *a, **kw: dummy_engine)
+    monkeypatch.setattr(server.SQLModel.metadata, "create_all", lambda *a, **k: None)
+
+    app = server.create_app()
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health")
+            assert resp.status_code == 200
+    assert dummy_engine.disposed

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_module_entrypoint():
+    proc = subprocess.run([sys.executable, '-m', 'moogla', '--help'], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert 'Moogla command line interface' in proc.stdout


### PR DESCRIPTION
## Summary
- close redis connections and dispose of the database engine on shutdown
- expose `python -m moogla` entrypoint
- test that engine is disposed on application shutdown
- test running the module as `python -m moogla`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a72917b88332829af17669007bfa