### PR TITLE
Improve plugin config handling and expose version API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ modular, observable and developer friendly.
 - Local or remote model execution with streaming responses
 - Expandable plugin system with async hooks and CLI management
 - FastAPI server exposing OpenAI compatible endpoints
+- Small /version endpoint for health checks and client introspection
 - Optional API authentication via API key or JWT
 - Redis‑backed rate limiting
 - Built‑in dark‑mode web UI with file uploads and quick hints

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -42,13 +42,17 @@ class PluginStore:
     def save(self, data: Dict[str, Any]) -> None:
         path = self._resolve_path()
         path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
         try:
-            with open(path, "w", encoding="utf-8") as f:
+            with open(tmp, "w", encoding="utf-8") as f:
                 if path.suffix in {".yaml", ".yml"}:
                     yaml.safe_dump(data, f)
                 else:
-                    json.dump(data, f, indent=2)
+                    json.dump(data, f, indent=2, sort_keys=True)
+            os.replace(tmp, path)
         except OSError as e:  # pragma: no cover - filesystem errors
+            if tmp.exists():
+                tmp.unlink(missing_ok=True)
             raise RuntimeError(f"Failed to save plugin config: {e}") from e
 
     def get_plugins(self) -> List[str]:

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -185,6 +185,13 @@ def create_app(
         """Return a simple heartbeat response for monitoring."""
         return {"status": "ok"}
 
+    @app.get("/version")
+    def version_info():
+        """Return the running package version."""
+        from . import __version__
+
+        return {"version": __version__}
+
     @app.get("/models")
     def list_models():
         """Return available model filenames from the configured directory."""

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from moogla.server import create_app
+from moogla import __version__
+
+
+def test_version_endpoint():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": __version__}


### PR DESCRIPTION
## Summary
- atomically write plugin configuration to avoid corruption
- add a simple `/version` endpoint
- document the new endpoint
- test version endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a8ef838c833287edbb3e606b2d7c