### PR TITLE
Improve configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,10 @@ can also be passed to `create_app` or `moogla serve`.
 Set `MOOGLA_CORS_ORIGINS` to send CORS headers for a comma-separated list of
 allowed origins.
 Set `MOOGLA_LOG_LEVEL` to control application logging (default `INFO`).
+Set `MOOGLA_HOST` and `MOOGLA_PORT` to change the bind address
+(defaults `127.0.0.1:11434`).
 These values can also be provided via the `--cors-origins`, `--log-level` and
-`--token-exp-minutes` options when running `moogla serve`.
+`--host`, `--port` and `--token-exp-minutes` options when running `moogla serve`.
 
 The API also exposes `/register` and `/login` endpoints for JWT-based
 authentication. POST a username and password to `/register` to persist a user

--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -95,8 +95,20 @@ def plugin_clear() -> None:
 
 @app.command()
 def serve(
-    host: str = "127.0.0.1",
-    port: int = 11434,
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help="IP or hostname to bind",
+        envvar="MOOGLA_HOST",
+        show_default=True,
+    ),
+    port: int = typer.Option(
+        11434,
+        "--port",
+        help="TCP port to listen on",
+        envvar="MOOGLA_PORT",
+        show_default=True,
+    ),
     plugin: List[str] = typer.Option(
         None, "--plugin", "-p", help="Plugin module to load", show_default=False
     ),

--- a/src/moogla/config.py
+++ b/src/moogla/config.py
@@ -32,5 +32,7 @@ class Settings(BaseSettings):
     )
     cors_origins: Optional[str] = Field(None, validation_alias="MOOGLA_CORS_ORIGINS")
     log_level: str = Field("INFO", validation_alias="MOOGLA_LOG_LEVEL")
+    host: str = Field("127.0.0.1", validation_alias="MOOGLA_HOST")
+    port: int = Field(11434, validation_alias="MOOGLA_PORT")
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -36,7 +36,11 @@ class PluginStore:
                 if path.suffix in {".yaml", ".yml"}:
                     return yaml.safe_load(f) or {}
                 return json.load(f)
-        except (OSError, json.JSONDecodeError, yaml.YAMLError) as e:  # pragma: no cover - file errors
+        except (
+            OSError,
+            json.JSONDecodeError,
+            yaml.YAMLError,
+        ) as e:  # pragma: no cover - file errors
             raise RuntimeError(f"Failed to load plugin config: {e}") from e
 
     def save(self, data: Dict[str, Any]) -> None:
@@ -138,4 +142,3 @@ def get_plugin_settings(name: str) -> Dict[str, Any]:
 
 def get_all_plugin_settings() -> Dict[str, Dict[str, Any]]:
     return _default.get_all_plugin_settings()
-

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -3,9 +3,9 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from pathlib import Path
 from typing import List, Optional
-from enum import Enum
 
 import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException


### PR DESCRIPTION
## Summary
- add environment variables and CLI flags for host and port
- document new options in README
- run pre-commit formatting

## Testing
- `pre-commit run --files src/moogla/config.py src/moogla/cli.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ac7386288332af4a8194cb279877