### PR TITLE
Improve logging

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import List
@@ -10,6 +11,8 @@ from dotenv import load_dotenv
 from . import plugins_config
 from .config import Settings
 from .server import start_server
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -270,10 +273,11 @@ def pull(
                         f.write(chunk)
                         if total:
                             bar.update(len(chunk))
-        except Exception as e:
+        except Exception as exc:
             if dest.exists():
                 dest.unlink()
-            typer.echo(f"Failed to download {url}: {e}", err=True)
+            logger.error("Failed to download %s: %s", url, exc)
+            typer.echo(f"Failed to download {url}: {exc}", err=True)
             raise typer.Exit(code=1)
     elif Path(model).is_file():
         size = os.path.getsize(model)

--- a/src/moogla/executor.py
+++ b/src/moogla/executor.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from pathlib import Path
 from typing import Optional
 
 import openai
+
+logger = logging.getLogger(__name__)
 
 # Default generation parameters
 DEFAULT_MAX_TOKENS = 16
@@ -263,8 +266,8 @@ class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
         if self.client:
             try:
                 self.client.close()
-            except Exception:  # pragma: no cover - depends on backend implementation
-                pass
+            except Exception as exc:  # pragma: no cover - depends on backend implementation
+                logger.debug("LLM client close failed: %s", exc)
         if self.generator:
             close_fn = getattr(self.generator, "close", None)
             if callable(close_fn):
@@ -275,8 +278,8 @@ class LLMExecutor(AbstractContextManager, AbstractAsyncContextManager):
         if self.async_client:
             try:
                 await self.async_client.close()
-            except Exception:  # pragma: no cover - depends on backend implementation
-                pass
+            except Exception as exc:  # pragma: no cover - depends on backend implementation
+                logger.debug("Async LLM client close failed: %s", exc)
         await asyncio.to_thread(self.close)
 
     # Context manager support -------------------------------------------------


### PR DESCRIPTION
## Summary
- add structured logging to CLI and executor modules
- log failures when closing client connections or downloading models

## Testing
- `ruff check src tests`
- `pytest -q`
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_6866b2db00c8833294b815f7175ddd08