### PR TITLE
Improve package version handling

### DIFF
--- a/src/moogla/__init__.py
+++ b/src/moogla/__init__.py
@@ -1,8 +1,11 @@
 """Moogla core package."""
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 from .executor import LLMExecutor
 
 __all__ = ["__version__", "LLMExecutor"]
-__version__ = version("moogla")
+try:
+    __version__ = version("moogla")
+except PackageNotFoundError:  # pragma: no cover - fallback for editable installs
+    __version__ = "0.0.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,10 @@
+import importlib
+from importlib import metadata
+
 from fastapi.testclient import TestClient
-from moogla.server import create_app
+
 from moogla import __version__
+from moogla.server import create_app
 
 
 def test_version_endpoint():
@@ -9,3 +13,14 @@ def test_version_endpoint():
     resp = client.get("/version")
     assert resp.status_code == 200
     assert resp.json() == {"version": __version__}
+
+
+def test_version_fallback(monkeypatch):
+    """Package version should default when metadata is missing."""
+
+    def raise_not_found(_: str):
+        raise metadata.PackageNotFoundError
+
+    monkeypatch.setattr(metadata, "version", raise_not_found)
+    mod = importlib.reload(importlib.import_module("moogla"))
+    assert mod.__version__ == "0.0.0"


### PR DESCRIPTION
## Summary
- avoid failing when package metadata isn't found
- test fallback path for `__version__`

## Testing
- `pre-commit run --files src/moogla/__init__.py tests/test_version.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b56f47c08332ad00b47fa4679738