### PR TITLE
Improve plugin typing and server cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration for Moogla
+# Copy this file to `.env` and adjust values as needed.
+
+OPENAI_API_KEY=sk-your-key
+MOOGLA_MODEL_DIR=/path/to/models
+MOOGLA_RATE_LIMIT=30
+MOOGLA_REDIS_URL=redis://localhost:6379
+MOOGLA_DB_URL=sqlite:///moogla.db
+MOOGLA_JWT_SECRET=change-me
+MOOGLA_PLUGIN_FILE=/path/to/plugins.yaml
+MOOGLA_CORS_ORIGINS=https://example.com
+MOOGLA_LOG_LEVEL=INFO
+MOOGLA_HOST=127.0.0.1
+MOOGLA_PORT=11434


### PR DESCRIPTION
## Summary
- add `PluginModule` protocol for typed hooks
- centralize logging setup in `configure_logging`
- ensure resources close via `AsyncExitStack`
- provide example `.env` configuration

## Testing
- `pre-commit run --files src/moogla/plugins.py src/moogla/server.py .env.example` *(fails: files modified by hooks)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b87563748332a0646e60eda18467