### PR TITLE
Improve plugin configuration validation

### DIFF
--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -108,6 +108,15 @@ def test_corrupted_file_raises_runtime_error(tmp_path, monkeypatch):
         plugins_config.get_plugins()
 
 
+def test_invalid_structure_raises_runtime_error(tmp_path, monkeypatch):
+    cfg = tmp_path / "plugins.yaml"
+    cfg.write_text("plugins: foo")
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
+
+    with pytest.raises(RuntimeError):
+        plugins_config.get_plugins()
+
+
 def test_permission_error_raises_runtime_error(tmp_path, monkeypatch):
     cfg = tmp_path / "plugins.yaml"
     cfg.write_text("plugins: []")


### PR DESCRIPTION
## Summary
- validate plugin configuration files with Pydantic
- cover invalid plugin config structure in tests

## Testing
- `pytest -q`
- `pytest tests/test_plugin_config.py::test_invalid_structure_raises_runtime_error -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bf6ad9188332a5b8d2c2d4868924