### PR TITLE
Add config inspection and logging improvements

### DIFF
--- a/src/moogla/cli.py
+++ b/src/moogla/cli.py
@@ -96,10 +96,23 @@ def plugin_clear() -> None:
     typer.echo("Cleared plugin configuration")
 
 
+@plugin_app.command("path")
+def plugin_path() -> None:
+    """Show the path to the plugin configuration file."""
+    typer.echo(str(plugins_config.get_path()))
+
+
 @app.command()
 def version() -> None:
     """Show the installed Moogla version."""
     typer.echo(__version__)
+
+
+@app.command()
+def config() -> None:
+    """Show the effective configuration values."""
+    settings = Settings()
+    typer.echo(settings.model_dump_json(indent=2))
 
 
 @app.command()

--- a/src/moogla/plugins_config.py
+++ b/src/moogla/plugins_config.py
@@ -31,6 +31,10 @@ class PluginStore:
     def set_path(self, path: Optional[str]) -> None:
         self.path = Path(path) if path else self.DEFAULT_FILE
 
+    def get_path(self) -> Path:
+        """Return the configured plugin file path."""
+        return self._resolve_path()
+
     def _resolve_path(self) -> Path:
         env = os.getenv("MOOGLA_PLUGIN_FILE")
         if env:
@@ -158,3 +162,8 @@ def get_plugin_settings(name: str) -> Dict[str, Any]:
 
 def get_all_plugin_settings() -> Dict[str, Dict[str, Any]]:
     return _default.get_all_plugin_settings()
+
+
+def get_path() -> Path:
+    """Return the active plugin configuration file path."""
+    return _default.get_path()

--- a/src/moogla/server.py
+++ b/src/moogla/server.py
@@ -29,8 +29,15 @@ logger = logging.getLogger(__name__)
 
 
 def configure_logging(level: str) -> None:
-    """Configure application logging."""
-    logging.basicConfig(level=level)
+    """Configure application logging with a consistent format."""
+    root = logging.getLogger()
+    if not root.handlers:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )
+    else:
+        root.setLevel(level)
 
 
 def create_app(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,6 +257,14 @@ def test_plugin_show_command(tmp_path, monkeypatch):
     assert "number=1" in result.output
 
 
+def test_plugin_path_command(tmp_path, monkeypatch):
+    cfg = tmp_path / "plugins.yaml"
+    monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
+    result = runner.invoke(app, ["plugin", "path"])
+    assert result.exit_code == 0
+    assert cfg.name in result.output
+
+
 def test_reload_plugins_command(monkeypatch, tmp_path):
     cfg = tmp_path / "plugins.yaml"
     monkeypatch.setenv("MOOGLA_PLUGIN_FILE", str(cfg))
@@ -314,6 +322,13 @@ def test_version_option():
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert __version__ in result.output
+
+
+def test_config_command(monkeypatch):
+    monkeypatch.setenv("MOOGLA_MODEL", "dummy")
+    result = runner.invoke(app, ["config"])
+    assert result.exit_code == 0
+    assert '"model": "dummy"' in result.output
 
 
 def test_serve_invalid_db_url(monkeypatch):


### PR DESCRIPTION
## Summary
- expose plugin config path via CLI
- add `config` command to dump environment settings
- enhance server logging format
- update plugin config helpers accordingly
- test new CLI features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ccb159908332a09b82e79d101864